### PR TITLE
Remove hardware_versions in devices.yml

### DIFF
--- a/thethingsproducts/devices.yml
+++ b/thethingsproducts/devices.yml
@@ -3,6 +3,3 @@ version: '3'
 devices:
   thethingsnode:
     name: The Things Node
-    hardware_versions:
-      - v1.0
-      - v2.0


### PR DESCRIPTION
`hardware_versions` is already indicated in the `{device}/versions.yml` file, so the data is currently located in two places.