### PR TITLE
Fix Profile IDs for The Things Node to match filenames

### DIFF
--- a/vendor/index.yaml
+++ b/vendor/index.yaml
@@ -1537,5 +1537,5 @@ vendors:
     name: Exedra General Trading and Contracting
     vendorID: 841
 
-  # - id: the-things-products
-  #   name: The Things Products
+  - id: the-things-products
+    name: The Things Products

--- a/vendor/the-things-products/the-things-node.yaml
+++ b/vendor/the-things-products/the-things-node.yaml
@@ -8,11 +8,11 @@ firmwareVersions:
       - '1.0'
     profiles:
       EU863-870:
-        id: the-things-node-eu868
+        id: the-things-node-868
         lorawanCertified: true
         codec: the-things-node-codec
       US902-928:
-        id: the-things-node-us915
+        id: the-things-node-915
         lorawanCertified: true
         codec: the-things-node-codec
 sensors:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Quickfix PR for an issue that came up while working on https://github.com/TheThingsNetwork/lorawan-stack/issues/3433. Profile IDs for The Things Node do not match with the existing files.

#### Changes
<!-- What are the changes made in this pull request? -->

- Rename profile `the-things-node-eu868` to `the-things-node-868`, matching `the-things-node-868.yaml` file.
- Rename profile `the-things-node-us915` to `the-things-node-915`, matching `the-things-node-915.yaml` file.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

There should probably be a CI check that will make sure that no such inconsistencies are allowed.
