### PR TITLE
Fix Decentlab DL-DLR-002 sensor type

### DIFF
--- a/vendor/decentlab/dl-dlr2-004.yaml
+++ b/vendor/decentlab/dl-dlr2-004.yaml
@@ -32,6 +32,7 @@ firmwareVersions:
 sensors:
   - analog input
   - current
+  - 4-20 ma
   - battery
 
 dimensions:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

Add DL-DLR-002 sensor type. 


#### Changes
<!-- What are the changes made in this pull request? -->

Add `4-20 ma` sensor in `vendor/decentlab/dl-dlr2-004.yaml` thanks to 78270479.