### PR TITLE
Extend decentlab vendor fields 

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,21 @@ vendors:
     id: company-x
     # Vendor company name
     name: Company X
+    # Vendor company description (optional)
+    description:
     # LoRa Alliance issued Vendor ID
     vendorID: 10
     # Vendor website (optional)
     website: https://www.company-x.com
     # Vendor logo filename (optional)
     logo: logo.svg
+    # Vendor social media links and handles (optional)
+    social:
+      linkedin: https://www.linkedin.com/company/company-x/ # uri
+      facebook: https://www.facebook.com/company-x # uri
+      twitter: company-x  # handle
+      instagram: company-x # handle
+      github: company-x # handle
     # Organization Unique Identifiers (OUIs, six digit hex, optional): http://standards-oui.ieee.org/oui.txt
     # The OUI is typically the first 3 bytes of the DevEUI
     ouis:

--- a/vendor/index.yaml
+++ b/vendor/index.yaml
@@ -165,7 +165,8 @@ vendors:
     description: Decentlab is a Swiss company providing wireless sensor devices and services for distributed, cost-effective monitoring solutions. The sensor devices communicate wirelessly over LoRaWAN® and are designed for ultra low power consumption, capable of operating on batteries for several years. The devices are built for industrial applications and are ready to be deployed in any harsh indoor or outdoor environment. The service framework provides convenient access to measurement data and enables seamless integration into existing monitoring and control systems. Application areas are environmental and air quality monitoring, hydrological measurements, smart agriculture and smart cities.
     social:
       linkedin: https://www.linkedin.com/company/decentlab/
-      twitter: https://twitter.com/decentlab
+      twitter: decentlab
+      github: decentlab
 
   - id: definium
     name: Definium Technologies, Pty Ltd.

--- a/vendor/index.yaml
+++ b/vendor/index.yaml
@@ -162,6 +162,10 @@ vendors:
     logo: decentlab_logo.svg
     ouis:
       - 70B3D57BA
+    description: Decentlab is a Swiss company providing wireless sensor devices and services for distributed, cost-effective monitoring solutions. The sensor devices communicate wirelessly over LoRaWAN® and are designed for ultra low power consumption, capable of operating on batteries for several years. The devices are built for industrial applications and are ready to be deployed in any harsh indoor or outdoor environment. The service framework provides convenient access to measurement data and enables seamless integration into existing monitoring and control systems. Application areas are environmental and air quality monitoring, hydrological measurements, smart agriculture and smart cities.
+    social:
+      linkedin: https://www.linkedin.com/company/decentlab/
+      twitter: https://twitter.com/decentlab
 
   - id: definium
     name: Definium Technologies, Pty Ltd.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

As part of the new device repository website we will be generating partner landing pages. These pages are lacking in company data. 

<img width="1261" alt="Screenshot 2021-04-29 at 10 49 51" src="https://user-images.githubusercontent.com/46600603/116525330-b2bc0180-a8d8-11eb-90a8-f62fb03b6af3.png">

Here is an example how we could extend the vendor data in the repo. 
An alternative could be to include it here `vendor/index.yaml` but I did not want to over populate this file.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add vendor `description`, `vendorURL` and `social` links

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Other suggestions included including vendor `location` do you have a good suggestion for a formatted way of including this? 

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.

Always mention changes in API.
-->

- Add vendor `description`, `vendorURL` and `social` links to decentlab
