### PR TITLE
Fix duplicate og title names

### DIFF
--- a/website/config/_default/config.toml
+++ b/website/config/_default/config.toml
@@ -1,6 +1,6 @@
 baseURL = "https://thethingsnetwork.org/device-repository/"
 languageCode = "en-us"
-title = "Device Repository"
+title = "LoRaWAN Device Repository"
 
 [taxonomies]
   tag = "tags"
@@ -10,5 +10,5 @@ title = "Device Repository"
   github = "https://github.com/TheThingsNetwork/lorawan-devices"
   facebook = "https://www.facebook.com/thethingsnetwork"
   og_image = "assets/ttn_profile_picture_white_bg.png"
-  sitename = "Device Repository"
+  sitename = "The Things Network"
   twitter = "@thethingsntwrk"

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Device Repository"
+title: "Devices"
 description: "The LoRaWAN® Device Repository features the most popular products within the LoRaWAN Ecosystem. It began as a physical wall, but it's now launching as a virtual wall as part of The Things Conference 2021!"
 weight: 1
 ---


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

og:site_name = 'The Things Network'
page title = '{{ .Title }} | LoRaWAN Device repository'


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->


The homepage title was repeated.

<img width="681" alt="Screenshot 2021-05-26 at 10 43 29" src="https://user-images.githubusercontent.com/46600603/119631113-df980180-be0f-11eb-9c0c-06062a84356d.png">

