### PR TITLE
Update oyster.js

### DIFF
--- a/vendor/digital-matter/oyster-codec.yaml
+++ b/vendor/digital-matter/oyster-codec.yaml
@@ -1,18 +1,34 @@
 uplinkDecoder:
   fileName: oyster.js
   examples:
-    - description: Position update
+    - description: Position update fix valid
       input:
         fPort: 1
         bytes: [0x00, 0x30, 0xed, 0xec, 0x00, 0x32, 0x24, 0x45, 0x00, 0x00, 0xde]
       output:
         data:
+          type: 'position'
           batV: 5.55
           fixFailed: false
-          headingDeg: 0
           inTrip: false
+          manDown: null
           latitudeDeg: -32
           longitudeDeg: 116
-          manDown: null
           speedKmph: 0
+          headingDeg: 0
+    - description: Position update fix failed
+      input:
+        fPort: 1
+        bytes: [0x85, 0xa8, 0xc5, 0xeb, 0xd8, 0x76, 0x3f, 0x0b, 0x03, 0x01, 0xbe]
+      output:
+        data:
           type: 'position'
+          batV: 4.75
+          fixFailed: true
+          inTrip: true
+          manDown: null
+          cache:
+            latitudeDeg: -33.9367803
+            longitudeDeg: 18.8708568
+            speedKmph: 1
+            headingDeg: 0

--- a/vendor/digital-matter/oyster-codec.yaml
+++ b/vendor/digital-matter/oyster-codec.yaml
@@ -7,7 +7,7 @@ uplinkDecoder:
         bytes: [0x00, 0x30, 0xed, 0xec, 0x00, 0x32, 0x24, 0x45, 0x00, 0x00, 0xde]
       output:
         data:
-          type: 'position'
+          type: position
           batV: 5.55
           fixFailed: false
           inTrip: false
@@ -21,13 +21,15 @@ uplinkDecoder:
         fPort: 1
         bytes: [0x85, 0xa8, 0xc5, 0xeb, 0xd8, 0x76, 0x3f, 0x0b, 0x03, 0x01, 0xbe]
       output:
+        warnings:
+          - fix failed
         data:
-          type: 'position'
+          type: position
           batV: 4.75
           fixFailed: true
           inTrip: true
           manDown: null
-          cache:
+          cached:
             latitudeDeg: -33.9367803
             longitudeDeg: 18.8708568
             speedKmph: 1

--- a/vendor/digital-matter/oyster-codec.yaml
+++ b/vendor/digital-matter/oyster-codec.yaml
@@ -6,6 +6,7 @@ uplinkDecoder:
         fPort: 1
         bytes: [0x00, 0x30, 0xed, 0xec, 0x00, 0x32, 0x24, 0x45, 0x00, 0x00, 0xde]
       output:
+        warnings: []
         data:
           type: position
           batV: 5.55

--- a/vendor/digital-matter/oyster.js
+++ b/vendor/digital-matter/oyster.js
@@ -3,6 +3,8 @@ function decodeUplink(input)
   var port = input.fPort;
   var bytes = input.bytes;
   var decoded = {};
+  var location = {};
+  var warnings = [];
 
   if (port === 1)
   {
@@ -14,7 +16,6 @@ function decodeUplink(input)
 
     decoded.manDown = null;
 
-    var location = {};
     location.latitudeDeg = bytes[0] +
                            bytes[1] * 256 +
                            bytes[2] * 65536 +
@@ -38,6 +39,7 @@ function decodeUplink(input)
 
     if (decoded.fixFailed) {
       decoded.cached = location;
+      warnings.push("fix failed");
     } else {
       decoded = Object.assign(decoded, location);
     }
@@ -73,6 +75,7 @@ function decodeUplink(input)
 
     if (decoded.fixFailed) {
       decoded.cached = location;
+      warnings.push("fix failed");
     } else {
       decoded = Object.assign(decoded, location);
     }
@@ -111,5 +114,6 @@ function decodeUplink(input)
 
   return {
     data: decoded,
+    warnings: warnings,
   };
 }

--- a/vendor/digital-matter/oyster.js
+++ b/vendor/digital-matter/oyster.js
@@ -8,56 +8,81 @@ function decodeUplink(input)
   {
     decoded.type = "position";
 
-    decoded.latitudeDeg = bytes[0] + bytes[1] * 256 +
-                          bytes[2] * 65536 + bytes[3] * 16777216;
-    if (decoded.latitudeDeg >= 0x80000000) // 2^31
-      decoded.latitudeDeg -= 0x100000000;  // 2^32
-    decoded.latitudeDeg /= 1e7;
-
-    decoded.longitudeDeg = bytes[4] + bytes[5] * 256 +
-                           bytes[6] * 65536 + bytes[7] * 16777216;
-    if (decoded.longitudeDeg >= 0x80000000) // 2^31
-      decoded.longitudeDeg -= 0x100000000;  // 2^32
-    decoded.longitudeDeg /= 1e7;
-
-    decoded.inTrip    = ((bytes[8] & 0x1) !== 0) ? true : false;
-    decoded.fixFailed = ((bytes[8] & 0x2) !== 0) ? true : false;
-    decoded.headingDeg = (bytes[8] >> 2) * 5.625;
-
-    decoded.speedKmph = bytes[9];
+    decoded.inTrip    = ((bytes[8] & 0x1) !== 0);
+    decoded.fixFailed = ((bytes[8] & 0x2) !== 0);
     decoded.batV = Number((bytes[10] * 0.025).toFixed(2));
 
     decoded.manDown = null;
+
+    var location = {};
+    location.latitudeDeg = bytes[0] +
+                           bytes[1] * 256 +
+                           bytes[2] * 65536 +
+                           bytes[3] * 16777216;
+    if (location.latitudeDeg >= 0x80000000) { // 2^31
+      location.latitudeDeg -= 0x100000000;  // 2^32
+    }
+    location.latitudeDeg /= 1e7;
+
+    location.longitudeDeg = bytes[4] +
+                            bytes[5] * 256 +
+                            bytes[6] * 65536 +
+                            bytes[7] * 16777216;
+    if (location.longitudeDeg >= 0x80000000) { // 2^31
+      location.longitudeDeg -= 0x100000000;  // 2^32
+    }
+    location.longitudeDeg /= 1e7;
+    
+    location.headingDeg = (bytes[8] >> 2) * 5.625;
+    location.speedKmph = bytes[9];
+
+    if (decoded.fixFailed) {
+      decoded.cached = location;
+    } else {
+      decoded = Object.assign(decoded, location);
+    }
   }
   else if (port === 4)
   {
     decoded.type = "position";
 
-    decoded.latitudeDeg = bytes[0] + bytes[1] * 256 + bytes[2] * 65536;
-    if (decoded.latitudeDeg >= 0x800000) // 2^23
-      decoded.latitudeDeg -= 0x1000000;  // 2^24
-    decoded.latitudeDeg *= 256e-7;
-
-    decoded.longitudeDeg = bytes[3] + bytes[4] * 256 + bytes[5] * 65536;
-    if (decoded.longitudeDeg >= 0x800000) // 2^23
-      decoded.longitudeDeg -= 0x1000000;  // 2^24
-    decoded.longitudeDeg *= 256e-7;
-
-    decoded.headingDeg = (bytes[6] & 0x7) * 45;
-    decoded.speedKmph = (bytes[6] >> 3) * 5;
-
     decoded.batV = Number((bytes[7] * 0.025).toFixed(2));
 
-    decoded.inTrip    = ((bytes[8] & 0x1) !== 0) ? true : false;
-    decoded.fixFailed = ((bytes[8] & 0x2) !== 0) ? true : false;
-    decoded.manDown   = ((bytes[8] & 0x4) !== 0) ? true : false;
+    decoded.inTrip    = ((bytes[8] & 0x1) !== 0);
+    decoded.fixFailed = ((bytes[8] & 0x2) !== 0);
+    decoded.manDown   = ((bytes[8] & 0x4) !== 0);
+
+    location.latitudeDeg = bytes[0] + 
+                           bytes[1] * 256 + 
+                           bytes[2] * 65536;
+    if (location.latitudeDeg >= 0x800000) { // 2^23
+      location.latitudeDeg -= 0x1000000;  // 2^24
+    }
+    location.latitudeDeg *= 256e-7;
+
+    location.longitudeDeg = bytes[3] +
+                            bytes[4] * 256 +
+                            bytes[5] * 65536;
+    if (location.longitudeDeg >= 0x800000) { // 2^23
+      location.longitudeDeg -= 0x1000000;  // 2^24
+    }
+    location.longitudeDeg *= 256e-7;
+
+    location.headingDeg = (bytes[6] & 0x7) * 45;
+    location.speedKmph = (bytes[6] >> 3) * 5;
+
+    if (decoded.fixFailed) {
+      decoded.cached = location;
+    } else {
+      decoded = Object.assign(decoded, location);
+    }
   }
   else if (port === 2)
   {
     decoded.type = "downlink ack";
 
     decoded.sequence = (bytes[0] & 0x7F);
-    decoded.accepted = ((bytes[0] & 0x80) !== 0) ? true : false;
+    decoded.accepted = ((bytes[0] & 0x80) !== 0);
     decoded.fwMaj = bytes[1];
     decoded.fwMin = bytes[2];
   }


### PR DESCRIPTION
If fix failed, add location into a cache sub-object.

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fixes #233 

When fix failed, write latitude, longitude, speed, heading into a cache object, indicating that it is a cached location and not a real time location.

#### Changes
<!-- What are the changes made in this pull request? -->

- Latitude, longitude, speed, heading into cache
- Simplify boolean checks

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Example payload for fixFailed=true: `85A8C5EBD8763F0B0301BE`
Example payload for fixFailed=false: `94A3C5EB77743F0B0000BE`

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.

Always mention changes in API.
-->

- ...
