### PR TITLE
Fix Elsys profile vendor

### DIFF
--- a/vendor/elsys/ers-co2.yaml
+++ b/vendor/elsys/ers-co2.yaml
@@ -27,12 +27,6 @@ firmwareVersions:
     # RU864-870
     profiles:
       EU863-870:
-        # Optional identifier of the vendor of the profile. When you specify the vendorID, the profile is loaded from
-        # the vendorID's folder. This allows you to reuse profiles from module or LoRaWAN end device stack vendors.
-        # If vendorID is empty, the current vendor ID is used. In this example, the vendorID is the current vendor ID,
-        # which is verbose.
-        vendorID: example
-        # Identifier of the profile (lowercase, alphanumeric with dashes, max 36 characters)
         id: elsys-eu868-profile
         lorawanCertified: true
         codec: ers-co2-codec


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Remove `example` vendor ID from Elsys EU 868 profile. Bumped into this while testing.
