### PR TITLE
Fix Datasheet URL yaml field

### DIFF
--- a/website/tools/build/pkg/devicerepository/devicerepository.go
+++ b/website/tools/build/pkg/devicerepository/devicerepository.go
@@ -99,7 +99,7 @@ type EndDevice struct {
 		Other []string `yaml:"other"`
 	} `yaml:"videos"`
 	ProductURL   string `yaml:"productURL"`
-	DatasheetURL string `yaml:"datasheetURL"`
+	DataSheetURL string `yaml:"dataSheetURL"`
 	ResellerURLs []struct {
 		Name   string   `yaml:"name"`
 		Region []string `yaml:"region"`


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
The correct field name is `dataSheetURL`. This field does not appear to be used anywhere so far, but good to fix just in case.

cc @mjamescompton 