### PR TITLE
arduino/mkr-wan-1310: Updates profile to include AU915-928 region

### DIFF
--- a/vendor/arduino/mkr-wan-1310.yaml
+++ b/vendor/arduino/mkr-wan-1310.yaml
@@ -27,6 +27,29 @@ firmwareVersions:
         lorawanCertified: true
         codec: mkrwan1310-codec
 
+  - # Firmware version
+    version: '1.2.3'
+    numeric: 2
+    # Corresponding hardware versions (optional)
+    hardwareVersions:
+      - '1.0'
+
+    # LoRaWAN Device Profiles per region
+    # Supported regions are EU863-870, US902-928, AU915-928, AS923, CN779-787, EU433, CN470-510, KR920-923, IN865-867, RU864-870
+    profiles:
+      EU863-870:
+        id: arduino-868-profile
+        lorawanCertified: true
+        codec: mkrwan1310-codec
+      US902-928:
+        id: arduino-915-profile
+        lorawanCertified: true
+        codec: mkrwan1310-codec
+      AU915-928:
+        id: arduino-915-profile
+        lorawanCertified: false
+        codec: mkrwan1310-codec
+
 # Dimensions in mm (optional)
 # Use width, height, length and/or diameter
 dimensions:


### PR DESCRIPTION
The AU915-928 region band plan requires firmware 1.2.3 on the device correctly.
This change is should have been made by Arduino SA but has not been done yet.

#### Summary
Add AU915-928 Region Bandplan, which was not in the existing device files.

#### Changes
This change modifies the definition file, copies the existing configuration and adds a definition for AU915-928.

#### Notes for Reviewers
For the MKRWAN1310 to work correctly with the AU915-928 bandplan, the MKRWAN1310 need to be upgraded to the 1.2.3 version of the firmware (latest at the time of this commit).

The existing definitions for EU863-870 and US902-928 have also been carried forward to firmware definition 1.2.3 but this has not been tested.

This is  a community change request and not an official change request from Arduino SA.
