### PR TITLE
Fix decoder for LGT-92 fw version 1.5/1.6 devices

### DIFF
--- a/vendor/dragino/lgt92-codec.yaml
+++ b/vendor/dragino/lgt92-codec.yaml
@@ -4,9 +4,46 @@ uplinkDecoder:
     - description: Distance Detection
       input:
         fPort: 2
-        bytes: [0x01, 0x5A, 0x78, 0x54, 0x06, 0xCF, 0x33, 0xD8, 0x0D, 0x20, 0x60, 0x00, 0x4B, 0x01, 0x90, 0x00]
+        bytes: [0x01, 0x5A, 0x78, 0x54, 0x06, 0xCF, 0x33, 0xD8, 0x0D, 0x20, 0x60, 0x00, 0x4B, 0x01, 0x90]
       output:
-        data: { 'ALARM_status': 'FALSE', 'altitude': 0, 'BatV': 3.36, 'FW': 160, 'LON': 'ON', 'latitude': 22.70626, 'longitude': 114.24252, 'MD': 'Disable', 'Pitch': 4, 'Roll': 0.75, 'hdop': 0 }
+        data: { 'ALARM_status': false, 'BatV': 3.36, 'FW': 160, 'LON': true, 'latitude': 22.70626, 'longitude': 114.24252, 'MD': 'Move', 'Pitch': 4, 'Roll': 0.75 }
+
+    - description: 'Example from 1.5 manual'
+      input:
+        fPort: 2
+        bytes: [0x02, 0x86, 0x3D, 0x68, 0xFA, 0xC2, 0x9B, 0xAF, 0x4B, 0x45, 0x60, 0x04, 0xD2, 0xFB, 0x2E]
+      output:
+        data: { 'latitude': 42.351976, 'longitude': -87.909457, 'ALARM_status': true, 'BatV': 2.885, 'MD': 'Move', 'LON': true, 'FW': 160, 'Roll': 12.34, 'Pitch': -12.34 }
+
+    - description: 'Example from 1.6 manual'
+      input:
+        fPort: 2
+        bytes: [0x02, 0x86, 0x3D, 0x68, 0xFA, 0xC2, 0x9B, 0xAF, 0x4B, 0x45, 0x60, 0x04, 0xD2, 0xFB, 0x2E, 0xAB, 0x07, 0x80]
+      output:
+        data: { 'latitude': 42.351976, 'longitude': -87.909457, 'ALARM_status': true, 'BatV': 2.885, 'MD': 'Move', 'LON': true, 'FW': 160, 'hdop': 1.71, 'altitude': 19.2, 'Roll': 12.34, 'Pitch': -12.34 }
+
+    - description: 'Most Significant Byte zero'
+      input:
+        fPort: 2
+        bytes: [ 0x02, 0xfa, 0xcb, 0x30, 0x00, 0x80, 0xec, 0xf9, 0x0c, 0x2e, 0x64 ]
+      output:
+        data: { 'latitude': 49.990448, 'longitude': 8.449273, 'ALARM_status': false, 'BatV': 3.118, 'MD': 'Move', 'LON': true, 'FW': 164 }
+
+    - description: No Location
+      input:
+        fPort: 2
+        bytes: [ 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0c, 0x2e, 0x64 ]
+      output:
+        data: { 'ALARM_status': false, 'BatV': 3.118, 'MD': 'Move', 'LON': true, 'FW': 164 }
+        warnings: [ 'GPS failed to obtain location' ]
+
+    - description: Low Battery
+      input:
+        fPort: 2
+        bytes: [ 0x0f, 0xff, 0xff, 0xff, 0x0f, 0xff, 0xff, 0xff, 0x4b, 0x17, 0x64 ]
+      output:
+        data: { 'ALARM_status': true, 'BatV': 2.839, 'MD': 'Move', 'LON': true, 'FW': 164 }
+        warnings: [ 'GPS turned off because of low battery' ]
 
     - description: Unknown FPort
       input:

--- a/vendor/dragino/lgt92.js
+++ b/vendor/dragino/lgt92.js
@@ -1,65 +1,51 @@
+// See also:
+// https://www.dragino.com/downloads/index.php?dir=LGT_92/&file=LGT-92_LoRa_GPS_Tracker_UserManual_v1.5.5.pdf
+// https://www.dragino.com/downloads/index.php?dir=LGT_92/&file=LGT-92_LoRa_GPS_Tracker_UserManual_v1.6.8.pdf
+
+var movement = [ "Disable", "Move", "Collide", "User" ]
+
 function decodeUplink(input) {
-  var port = input.fPort;
-var bytes = input.bytes;
-var latitude=0;
-var data = {};
-    switch (input.fPort) {
-   case 2:
-if(bytes[0] !== 0)
-{
-  data.latitude=(bytes[0]<<24 | bytes[1]<<16 | bytes[2]<<8 | bytes[3])/1000000;//gps latitude,units: °
-}
-else
-{
-  data.latitude=0;//gps latitude,units: °
-}
-var longitude = 0;
-if(bytes[4] !== 0)
-{
-  data.longitude=(bytes[4]<<24 | bytes[5]<<16 | bytes[6]<<8 | bytes[7])/1000000;//gps longitude,units: °
-}
-else
-{
- data.longitude=0;//gps longitude,units: °
-}  
-data.ALARM_status=(bytes[8] & 0x40)?"TRUE":"FALSE";//Alarm status  
-data.BatV=(((bytes[8] & 0x3f) <<8) | bytes[9])/1000;//Battery,units:V  
-if(bytes[10] & 0xC0==0x40)
-{
-  var MD="Move";
-}
-else if(bytes[10] & 0xC0 ==0x80)
-{
-  data.MD="Collide";
-}
-else if(bytes[10] & 0xC0 ==0xC0)
-{
-  data.MD="User";
-}
-else
-{
-  data.MD="Disable";
-}                                            //mode of motion 
-data.LON=(bytes[10] & 0x20)?"ON":"OFF";//LED status for position,uplink and downlink 
-data.FW= 160+(bytes[10] & 0x1f);  // Firmware version; 5 bits   
-data.Roll=(bytes[11]<<8 | bytes[12])/100;//roll,units: ° 
-data.Pitch=(bytes[13]<<8 | bytes[14])/100; //pitch,units: ° 
-var hdop = 0;
-if(bytes[15] > 0)
-{
-   data.hdop =bytes[15]/100; //hdop,units: °
-}
-else
-{
-   data.hdop =bytes[15];
-}
-data.altitude =(bytes[16]<<8 | bytes[17]) / 100; //Altitude,units: °
-return {
-data:data,
-};
-  default:
-  return {
-    errors: ["unknown FPort"]
-  }
-}
+    if (input.fPort != 2) {
+        return {
+            errors: ['unknown FPort']
+        };
+    }
+    var bytes = input.bytes;
+    var warnings = [];
+    var d = {
+        latitude : ( (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3] ) / 1000000,
+        longitude: ( (bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7] ) / 1000000,
+        ALARM_status: !!(bytes[8] & (1 << 6)),
+        BatV: ( ((bytes[8] & 0x3f) << 8) | bytes[9] ) / 1000,
+        MD: movement[bytes[10] >> 6],
+        LON: !!(bytes[10] & (1 << 5)),
+        FW: 160 + (bytes[10] & 0x1f),  // NB: 1.5 firmware uses an offset of 150 ...
+    };
+
+    // i.e. latitude/longitude are set to 0x0fffffff which decodes to 268.xxx
+    if (d.BatV <= 2.84 && d.latitude > 268 && d.longitude > 268) {
+        delete d.latitude;
+        delete d.longitude;
+        warnings.push("GPS turned off because of low battery");
+    } else if (d.latitude == 0 && d.longitude == 0) {
+        delete d.latitude;
+        delete d.longitude;
+        warnings.push("GPS failed to obtain location");
+    }
+
+    switch (bytes.length) {
+        case 18: // GW verison 1.6
+            d.hdop     = bytes[15] / 100;
+            d.altitude = ( (bytes[16] << 24 >> 16) | bytes[17]) / 100;
+            // fall-through
+        case 15: // FW version 1.5
+            d.Roll     = ( (bytes[11] << 24 >> 16) | bytes[12]) / 100;
+            d.Pitch    = ( (bytes[13] << 24 >> 16) | bytes[14]) / 100;
+            break;
+    }
+
+    if (warnings.length > 0)
+        return { data: d, warnings: warnings };
+    else
+        return { data: d };
 }


### PR DESCRIPTION
Especially, it fixes the issue where longitude/latitude are set to zero
if the MSB is zero.

It also fixes the decoding of the Move-Direction (MD) field, where e.g.
'Move' was erroneously decoded as 'Disable', before.

While at it I also added some warnings for some special conditions.

It's a complete rewrite of the previous decoder in order to make it
shorter, easier reviewable and arguably simpler to review.

fixes #331

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
This pull request fixes decoding errors in the latitude/longitude/move-detection fields, explicitly supports firmware 1.5/1.6 devices, simplifies the decoder and adds some warnings.

Fixes #331

#### Changes
<!-- What are the changes made in this pull request? -->

- fix latitude/longitude decoding logic with respect to values where the MSB is zero
- fix mapping of move-direction values
- skip optional fields if not present instead of setting them to `0` or `null`
- add warnings for special GPS values
- explicitly support firmware version 1.5/1.6 devices
- reduce decoder code size

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Motivation: the decoding results of the existing decoder are buggy for my LGT-92 device.

The decoder now explicitly supports firmware version 1.5/1.6 devices and I stopped at support for 1.5 devices.
If there is a need I can also add support for firmware version 1.4 devices. But perhaps it's just and reasonable to just update the firmware on those devices.

I named the keys like in the existing decoder to keep them backwards compatible. But if there is a good reason I can also change them.

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.

Always mention changes in API.
-->

- fixed: decoding of small longitude/latitude values and move-direction values
- fixed: `LON` and `ALARM_status` fields  are decoded as booleans instead of boolean-like strings
- fixed: optional fields such as altitude are decoded only if present in the payload
