### PR TITLE
MLR003 REV1.1: Uplink is now 11 bytes

### DIFF
--- a/vendor/micropelt/mlr003-codec.yaml
+++ b/vendor/micropelt/mlr003-codec.yaml
@@ -4,7 +4,61 @@ uplinkDecoder:
   fileName: mlr003.js
   # Examples (optional)
   examples:
-    - description: Example 1
+    - description: REV1.1 Example 1
+      input:
+        fPort: 1
+        bytes: [0x3A, 0xCA, 0xD4, 0xF3, 0xA1, 0x21, 0x8B, 0x03, 0xEB, 0x50, 0x3A]
+      output:
+        data:
+          Current_Valve_Position: 58
+          Flow_Sensor_Raw: 101.00
+          Flow_Temperature: 106.00
+          Ambient_Sensor_Raw: 60.75
+          Ambient_Temperature: 40.25
+          Energy_Storage: 0
+          Harvesting_Active: 1
+          Ambient_Sensor_Failure: 0
+          Flow_Sensor_Failure: 0
+          Radio_Communication_Error: 0
+          Received_Signal_Strength: 0
+          Motor_Error: 1
+          Storage_Voltage: 2.78
+          Average_Current_Consumed: 30
+          Average_Current_Generated: 2350
+          Reference_Completed: 1
+          Operating_Mode: 0
+          Storage_Fully_Charged: 1
+          User_Mode: 0
+          User_Value: 58
+
+    - description: REV1.1 Example 2
+      input:
+        fPort: 1
+        bytes: [0x47, 0x19, 0x1B, 0x3C, 0x3C, 0x06, 0x75, 0x7B, 0x15, 0x01, 0x25]
+      output:
+        data:
+          Current_Valve_Position: 71
+          Flow_Sensor_Raw: 12.50
+          Flow_Temperature: 13.50
+          Ambient_Sensor_Raw: 15.00
+          Ambient_Temperature: 15.00
+          Energy_Storage: 0
+          Harvesting_Active: 0
+          Ambient_Sensor_Failure: 0
+          Flow_Sensor_Failure: 0
+          Radio_Communication_Error: 1
+          Received_Signal_Strength: 1
+          Motor_Error: 0
+          Storage_Voltage: 2.34
+          Average_Current_Consumed: 1230
+          Average_Current_Generated: 210
+          Reference_Completed: 0
+          Operating_Mode: 0
+          Storage_Fully_Charged: 0
+          User_Mode: 1
+          User_Value: 18.5
+
+    - description: REV1.0 Example 3
       input:
         fPort: 1
         bytes: [0x00, 0x3E, 0x42, 0x73, 0x60, 0x20, 0x87, 0x01, 0x02, 0x10]
@@ -29,7 +83,7 @@ uplinkDecoder:
           Operating_Mode: 0
           Storage_Fully_Charged: 0
 
-    - description: Example 2
+    - description: REV1.0 Example 4
       input:
         fPort: 1
         bytes: [0x64, 0x28, 0x2C, 0x4F, 0x4D, 0x00, 0x85, 0x01, 0x00, 0x10]

--- a/vendor/micropelt/mlr003.js
+++ b/vendor/micropelt/mlr003.js
@@ -1,9 +1,8 @@
 function decodeUplink(input) {
   switch (input.fPort) {
     case 1:
-      return {
-        // Decoded data
-        data: {
+      {
+        var output = {
           Current_Valve_Position: input.bytes[0],
           Flow_Sensor_Raw: input.bytes[1]*0.5,
           Flow_Temperature: input.bytes[2]*0.5,
@@ -12,21 +11,34 @@ function decodeUplink(input) {
           Energy_Storage: input.bytes[5]>>6 & 0x01,
           Harvesting_Active: input.bytes[5]>>5 & 0x01,
           Ambient_Sensor_Failure: input.bytes[5]>>4 & 0x01,
-          Flow_Sensor_Failure : input.bytes[5]>>3 & 0x01,
+          Flow_Sensor_Failure: input.bytes[5]>>3 & 0x01,
           Radio_Communication_Error: input.bytes[5]>>2 & 0x01,
           Received_Signal_Strength: input.bytes[5]>>1 & 0x01,
           Motor_Error: input.bytes[5]>>0 & 0x01,
-          Storage_Voltage: input.bytes[6]*0.02,
+          Storage_Voltage: Number((input.bytes[6]*0.02).toFixed(2)),
           Average_Current_Consumed: input.bytes[7]*10,
           Average_Current_Generated: input.bytes[8]*10,
           Reference_Completed: input.bytes[9]>>4 & 0x01,
           Operating_Mode: input.bytes[9]>>7 & 0x01,
-          Storage_Fully_Charged : input.bytes[9]>>6 & 0x01
-        },
-      };
-    default:
-      return {
-        errors: ['unknown FPort'],
-      };
+          Storage_Fully_Charged: input.bytes[9]>>6 & 0x01,
+        }
+        if (input.bytes.length == 11) {
+          var um = input.bytes[9] & 0x03
+          if (um == 0) {
+            var uv = input.bytes[10]
+          }
+          else {
+            var uv = input.bytes[10]*0.5
+          }
+          output.User_Mode = um
+          output.User_Value = uv
+        }
+        return { data: output };
+      }
+      default:
+        return {
+          errors: ['unknown FPort'],
+        };
+      }
+
   }
-}


### PR DESCRIPTION
Micropelt MLR003 REV1.1

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

The Uplink length has increased from 10 bytes to 11 bytes. The Uplink now includes the User Mode and User Value.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add decoding for Uplinks of length 11 bytes
- Add examples

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The code continues to support decoding of REV1.0 Uplinks, as well as being able to decode REV1.1 Uplinks.

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.

Always mention changes in API.
-->

- ...
