### PR TITLE
Fix RX2 frequency 869.525 MHz for vendor ESPEasy

### DIFF
--- a/vendor/espeasy/profile-eu868-class-a-abp-101.yaml
+++ b/vendor/espeasy/profile-eu868-class-a-abp-101.yaml
@@ -10,7 +10,7 @@ rx1DataRateOffset: 0
 # RX2 data rate index
 rx2DataRateIndex: 0
 # RX2 frequency (MHz)
-rx2Frequency: 868.525
+rx2Frequency: 869.525
 # Factory preset frequencies (MHz)
 factoryPresetFrequencies: [868.1, 868.3, 868.5, 867.1, 867.3, 867.5, 867.7, 867.9]
 

--- a/vendor/espeasy/profile-eu868-class-a-abp-102.yaml
+++ b/vendor/espeasy/profile-eu868-class-a-abp-102.yaml
@@ -10,7 +10,7 @@ rx1DataRateOffset: 0
 # RX2 data rate index
 rx2DataRateIndex: 0
 # RX2 frequency (MHz)
-rx2Frequency: 868.525
+rx2Frequency: 869.525
 # Factory preset frequencies (MHz)
 factoryPresetFrequencies: [868.1, 868.3, 868.5, 867.1, 867.3, 867.5, 867.7, 867.9]
 


### PR DESCRIPTION
#### Summary
PR #300 did not fix the RX2 frequency for vendor ESPEasy.
This PR should fix it.

#### Changes
- Change EU868 RX2 freq. for vendor ESPEasy

#### Notes for Reviewers
RX2 settings were discussed [on the forum](https://www.thethingsnetwork.org/forum/t/downlink-on-each-unconfirmed-uplink-abp/58059/23) where it appeared they are still incorrect in the ESPEasy vendor template.

#### Release Notes
- Correct EU868 RX2 frequency for vendor ESPEasy
