### PR TITLE
Fix dates

### DIFF
--- a/vendor/laird/rs1xx-ext-multi-sensor.js
+++ b/vendor/laird/rs1xx-ext-multi-sensor.js
@@ -668,7 +668,7 @@ function convertTimestampToDate(stream){
     date = new Date(timeInSeconds);
     // Get the month in textual format - an offset of 1 is needed for the
     // month due to the date using 0 based values.
-    month = getEnumValue(monthTypeEnum,true,date.getMonth() + 1);
+    month = getEnumValue(monthTypeEnum,true,date.getUTCMonth() + 1);
     // The rest of the data can be copied across directly
     result = {
         year : date.getUTCFullYear(),

--- a/vendor/laird/rs1xx-ext-temp-1w-sensor.js
+++ b/vendor/laird/rs1xx-ext-temp-1w-sensor.js
@@ -667,7 +667,7 @@ function convertTimestampToDate(stream){
     date = new Date(timeInSeconds);
     // Get the month in textual format - an offset of 1 is needed for the
     // month due to the date using 0 based values.
-    month = getEnumValue(monthTypeEnum,true,date.getMonth() + 1);
+    month = getEnumValue(monthTypeEnum,true,date.getUTCMonth() + 1);
     // The rest of the data can be copied across directly
     result = {
         year : date.getUTCFullYear(),

--- a/vendor/laird/rs1xx-ext-temp-rtd-sensor.js
+++ b/vendor/laird/rs1xx-ext-temp-rtd-sensor.js
@@ -667,7 +667,7 @@ function convertTimestampToDate(stream){
     date = new Date(timeInSeconds);
     // Get the month in textual format - an offset of 1 is needed for the
     // month due to the date using 0 based values.
-    month = getEnumValue(monthTypeEnum,true,date.getMonth() + 1);
+    month = getEnumValue(monthTypeEnum,true,date.getUTCMonth() + 1);
     // The rest of the data can be copied across directly
     result = {
         year : date.getUTCFullYear(),

--- a/vendor/laird/rs1xx-temp-rh-sensor.js
+++ b/vendor/laird/rs1xx-temp-rh-sensor.js
@@ -667,7 +667,7 @@ function convertTimestampToDate(stream){
     date = new Date(timeInSeconds);
     // Get the month in textual format - an offset of 1 is needed for the
     // month due to the date using 0 based values.
-    month = getEnumValue(monthTypeEnum,true,date.getMonth() + 1);
+    month = getEnumValue(monthTypeEnum,true,date.getUTCMonth() + 1);
     // The rest of the data can be copied across directly
     result = {
         year : date.getUTCFullYear(),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

@greg-leach Laird's codec uses local time, which gives errors in timezones with a negative offset to UTC:

```
./vendor/laird/rs1xx-ext-temp-rtd-sensor.js:decodeUplink: output {"data":{"msgType":"SendBackLogMessages","numberOfReadings":2,"options":["Sensor request for server time"],"readings":[{"temperature":0,"timestamp":{"day":1,"hours":0,"minutes":0,"month":"December","seconds":0,"year":2015}},{"temperature":0,"timestamp":{"day":1,"hours":0,"minutes":0,"month":"December","seconds":0,"year":2015}}]}} does not match {"data":{"msgType":"SendBackLogMessages","options":["Sensor request for server time"],"numberOfReadings":2,"readings":[{"timestamp":{"year":2015,"month":"January","day":1,"hours":0,"minutes":0,"seconds":0},"temperature":0},{"timestamp":{"year":2015,"month":"January","day":1,"hours":0,"minutes":0,"seconds":0},"temperature":0}]}}
```

(notice the different month: January vs December)

#### Changes
<!-- What are the changes made in this pull request? -->

Use UTC month