### PR TITLE
Adapted to new corporate identity of vendor KELLER

### DIFF
--- a/vendor/index.yaml
+++ b/vendor/index.yaml
@@ -338,13 +338,13 @@ vendors:
     vendorID: 220
 
   - id: keller
-    name: KELLER AG für Druckmesstechnik
+    name: KELLER Druckmesstechnik AG
     website: https://keller-druck.com/
     logo: keller-logo.svg
     vendorID: 222
-    description: KELLER AG, Europe's leading manufacturer of isolated pressure transducers and transmitters, was founded in 1974 by H. W. Keller, the inventor of the integrated silicon measuring cell. Piezoresitive pressure sensors have impressively high precision and pressure ranges from 5 mbar to 2000 bar. The KELLER product range includes digital manometers, level probes, data loggers and remote transmission units communicating wirelessly over LoRaWAN®, NB-IoT, LTE-M, LTE and more.
+    description: KELLER Pressure, Europe's leading manufacturer of isolated pressure transducers and transmitters, was founded in 1974 by H. W. Keller, the inventor of the integrated silicon measuring cell. Piezoresitive pressure sensors have impressively high precision and pressure ranges from 5 mbar to 2000 bar. The KELLER product range includes digital manometers, level probes, data loggers and remote transmission units communicating wirelessly over LoRaWAN®, NB-IoT, LTE-M, LTE and more.
     social:
-      linkedin: https://www.linkedin.com/company/keller-ag-f%C3%BCr-druckmesstechnik
+      linkedin: https://www.linkedin.com/company/keller-pressure
       github: KELLERAGfuerDruckmesstechnik
 
   - id: kerlink

--- a/vendor/keller/adt1-box.yaml
+++ b/vendor/keller/adt1-box.yaml
@@ -78,7 +78,7 @@ keySecurity: none
 #documentationURL: https://docs.kolibricloud.ch/sending-technology/lora-technology/
 #githubURL: https://github.com/KELLERAGfuerDruckmesstechnik
 productURL: https://keller-druck.com/en/products/data-loggers/remote-transmission-units-with-data-logger/adt1-box
-dataSheetURL: https://download.keller-druck.com/api/download/q3sWTxfeyHkzDXiezeoXjj/en/2020-10.pdf
+dataSheetURL: https://download.keller-druck.com/api/download/q3sWTxfeyHkzDXiezeoXjj/en/2022-08.pdf
 
 photos:
   main: adt1-box-open.jpg

--- a/vendor/keller/adt1-tube.yaml
+++ b/vendor/keller/adt1-tube.yaml
@@ -77,7 +77,7 @@ keySecurity: none
 #documentationURL: https://docs.kolibricloud.ch/sending-technology/lora-technology/
 #githubURL: https://github.com/KELLERAGfuerDruckmesstechnik
 productURL: https://keller-druck.com/en/products/data-loggers/remote-transmission-units-with-data-logger/adt1-tube
-dataSheetURL: https://download.keller-druck.com/api/download/q3sWTxfeyHkzDXiezeoXjj/en/2020-10.pdf
+dataSheetURL: https://download.keller-druck.com/api/download/q3sWTxfeyHkzDXiezeoXjj/en/2022-08.pdf
 
 photos:
   main: adt1-tube-open.jpg


### PR DESCRIPTION
#### Summary
- Adapted to new corporate identity of vendor KELLER

#### Changes
- Changed company name from "_KELLER für Druckmesstechnik AG_" to "_KELLER Druckmesstechnik AG_" rsp. "_KELLER Pressure_"
- Updated URL links to newer versions

#### Notes for Reviewers
- Only superficial changes. Should not break anything.
