### PR TITLE
Support normalized payload for Laird Sentrius RS1xx Temp-RH Sensor

### DIFF
--- a/vendor/laird/rs1xx-temp-rh-sensor-codec.yaml
+++ b/vendor/laird/rs1xx-temp-rh-sensor-codec.yaml
@@ -19,7 +19,7 @@ uplinkDecoder:
       normalizedOutput:
         data:
           - air:
-              temperature: 98.67
+              temperature: 37.03888888888889
               relativeHumidity: 52.33
 
     - description: Send Temp and RH Aggregated Data Notification
@@ -36,6 +36,16 @@ uplinkDecoder:
           numberOfReadings: 2
           timestamp: { year: 2015, month: 'January', day: 1, hours: 0, minutes: 0, seconds: 0 }
           readings: [{ temperature: 98.67, humidity: 52.33 }, { temperature: 99.68, humidity: 53.34 }]
+      normalizedOutput:
+        data:
+          - time: '2015-01-01T00:00:00.000Z'
+            air:
+              temperature: 37.03888888888889
+              relativeHumidity: 52.33
+          - time: '2015-01-01T00:00:00.000Z'
+            air:
+              temperature: 37.6
+              relativeHumidity: 53.34
 
     - description: Send Backlog Message Notification
       input:
@@ -48,6 +58,12 @@ uplinkDecoder:
           timestamp: { year: 2015, month: 'January', day: 1, hours: 0, minutes: 0, seconds: 2 }
           temperature: 107.76
           humidity: 61.42
+      normalizedOutput:
+        data:
+          - time: '2015-01-01T00:00:02.000Z'
+            air:
+              temperature: 42.08888888888889
+              relativeHumidity: 61.42
 
     - description: Send Backlog Messages Notification
       input:
@@ -63,6 +79,16 @@ uplinkDecoder:
               { timestamp: { year: 2015, month: 'January', day: 1, hours: 0, minutes: 0, seconds: 0 }, temperature: 107.76, humidity: 61.42 },
               { timestamp: { year: 2015, month: 'January', day: 1, hours: 0, minutes: 0, seconds: 0 }, temperature: 107.76, humidity: 61.42 },
             ]
+      normalizedOutput:
+        data:
+          - time: '2015-01-01T00:00:00.000Z'
+            air:
+              temperature: 42.08888888888889
+              relativeHumidity: 61.42
+          - time: '2015-01-01T00:00:00.000Z'
+            air:
+              temperature: 42.08888888888889
+              relativeHumidity: 61.42
 
     - description: Send Sensor Config Simple Notification
       input:

--- a/vendor/laird/rs1xx-temp-rh-sensor.js
+++ b/vendor/laird/rs1xx-temp-rh-sensor.js
@@ -3482,12 +3482,51 @@ function decodeUplink(input) {
 }
 
 function normalizeUplink(input) {
-    return {
-      data: {
-          air: {
-                temperature: input.data.temperature,
-                relativeHumidity: input.data.humidity,
-            }
+    parseDecodedTimestamp = (t) => {
+        return new Date(Date.UTC(
+            t.year,
+            monthTypeEnum.list.map(kv => kv.key).indexOf(t.month),
+            t.day,
+            t.hours,
+            t.minutes,
+            t.seconds,
+        )).toISOString();
     }
-  }
+
+    let rootTimestamp;
+    if ('timestamp' in input.data) {
+        rootTimestamp = parseDecodedTimestamp(input.data.timestamp);
+    }
+
+    if ('humidity' in input.data && 'temperature' in input.data) {
+        return {
+            data: {
+                ...(rootTimestamp ? { time: rootTimestamp } : {}),
+                air: {
+                    relativeHumidity: input.data.humidity,
+                    temperature: (input.data.temperature - 32) * 5 / 9
+                }
+            }
+        }
+    }
+
+    if ('readings' in input.data) {
+        return {
+            data: input.data.readings.map(r => {
+                let timestamp = rootTimestamp;
+                if ('timestamp' in r) {
+                    timestamp = parseDecodedTimestamp(r.timestamp);
+                }
+                return {
+                    ...(timestamp ? { time: timestamp } : {}),
+                    air: {
+                        relativeHumidity: r.humidity,
+                        temperature: (r.temperature - 32) * 5 / 9
+                    }
+                }
+            })
+        }
+    }
+
+    return;
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-devices/issues/395

#### Changes
<!-- What are the changes made in this pull request? -->

This pull request is more or less a simple demonstration of how this works for a Laird device.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@greg-leach I'm curious to your thoughts and comments if you have any.

Here's some background about normalized payload: https://www.thethingsindustries.com/docs/integrations/payload-formatters/javascript/uplink/#normalized-payload

Feel free also to join the discussion in #395 about adding more fields.

Of course, if there are mistakes in my code here, let me know and I can address it. Otherwise, this Laird device might be the first device supporting normalized payload in The Things Stack.