### PR TITLE
Add device version to `normalizeUplink()` input

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ deps.update:
 
 .PHONY: validate
 validate:
-	$(NPM) run validate
+	$(NPM) run validate -- --vendor="$(VENDOR)"
 
 .PHONY: fmt
 fmt:

--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ uplinkDecoder:
   # Examples (optional)
   examples:
     - description: 32 knots from the North
+      # Optional hardware versions for this codec example
+      hardwareVersions: ['1.0-2M']
       input:
         fPort: 1
         bytes: [0, 32]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ To validate data:
 $ make validate
 ```
 
+To validate only one vendor (much faster):
+
+```bash
+$ VENDOR=example make validate
+```
+
 [Visual Studio Code](https://code.visualstudio.com/) is a great editor for editing the Device Repository. You can validate your data automatically using the [YAML plugin](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml).
 
 The YAML plugin supports you with filling out the document. When hitting Ctrl + Space, all fields are shown. The Debug Console of Visual Studio provides feedback by highlighting the incorrect fields.

--- a/bin/validate.js
+++ b/bin/validate.js
@@ -12,12 +12,12 @@ const imageType = require('image-type');
 
 const ajv = new Ajv({ schemas: [require('../lib/payload.json'), require('../schema.json')] });
 
-const options = yargs.usage('Usage: --vendor <file>').option('v', {
+const options = yargs.usage('Usage: --vendor <id>').option('v', {
   alias: 'vendor',
-  describe: 'Path to vendor index file',
+  describe: 'Vendor ID',
   type: 'string',
   demandOption: true,
-  default: './vendor/index.yaml',
+  default: '',
 }).argv;
 
 let validateVendorsIndex = ajv.compile({
@@ -180,7 +180,7 @@ function formatValidationErrors(errors) {
   return errors.map((e) => `${e.dataPath} ${e.message}`);
 }
 
-const vendors = yaml.load(fs.readFileSync(options.vendor));
+const vendors = yaml.load(fs.readFileSync('./vendor/index.yaml'));
 
 if (!validateVendorsIndex(vendors)) {
   console.error(`${options.vendor} index is invalid: ${formatValidationErrors(validateVendorsIndex.errors)}`);
@@ -191,6 +191,10 @@ console.log(`vendor index: valid`);
 const vendorProfiles = {};
 
 vendors.vendors.forEach((v) => {
+  if (options.vendor && v.id !== options.vendor) {
+    return;
+  }
+
   const key = v.id;
   const folder = `./vendor/${v.id}`;
   if (v.logo) {

--- a/lib/payload.json
+++ b/lib/payload.json
@@ -64,6 +64,11 @@
             "direction": {
               "description": "Wind direction (°)",
               "$ref": "#/definitions/direction"
+            },
+            "elevation": {
+              "type": "number",
+              "description": "Elevation (cm)",
+              "minimum": 0
             }
           },
           "additionalProperties": false

--- a/schema.json
+++ b/schema.json
@@ -427,11 +427,38 @@
         "normalizeUplinkInput": {
           "type": "object",
           "properties": {
+            "version": {
+              "type": "object",
+              "properties": {
+                "vendorID": {
+                  "type": "string",
+                  "description": "Vendor identifier"
+                },
+                "endDeviceID": {
+                  "type": "string",
+                  "description": "End device identifier"
+                },
+                "hardwareVersion": {
+                  "type": "string",
+                  "description": "Hardware version",
+                  "minLength": 1
+                },
+                "firmwareVersion": {
+                  "type": "string",
+                  "description": "Firmware version",
+                  "minLength": 1
+                },
+                "region": {
+                  "$ref": "#/definitions/region"
+                }
+              },
+              "required": ["vendorID", "endDeviceID", "firmwareVersion", "region"]
+            },
             "data": {
               "type": "object"
             }
           },
-          "required": ["data"]
+          "required": ["version", "data"]
         },
         "normalizeUplinkOutput": {
           "allOf": [
@@ -474,6 +501,17 @@
                   "items": {
                     "type": "object",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "hardwareVersions": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "description": "Hardware version",
+                          "minLength": 1
+                        }
+                      },
                       "input": {
                         "$ref": "#/definitions/endDevicePayloadCodec/definitions/decodeInput"
                       },
@@ -483,7 +521,8 @@
                       "normalizedOutput": {
                         "$ref": "#/definitions/endDevicePayloadCodec/definitions/normalizeUplinkOutput"
                       }
-                    }
+                    },
+                    "additionalProperties": false
                   }
                 }
               }
@@ -501,13 +540,17 @@
                   "items": {
                     "type": "object",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
                       "input": {
                         "$ref": "#/definitions/endDevicePayloadCodec/definitions/encodeInput"
                       },
                       "output": {
                         "$ref": "#/definitions/endDevicePayloadCodec/definitions/encodeOutput"
                       }
-                    }
+                    },
+                    "additionalProperties": false
                   }
                 }
               }
@@ -525,13 +568,17 @@
                   "items": {
                     "type": "object",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
                       "input": {
                         "$ref": "#/definitions/endDevicePayloadCodec/definitions/decodeInput"
                       },
                       "output": {
                         "$ref": "#/definitions/endDevicePayloadCodec/definitions/decodeOutput"
                       }
-                    }
+                    },
+                    "additionalProperties": false
                   }
                 }
               }

--- a/vendor/example/windsensor-codec.yaml
+++ b/vendor/example/windsensor-codec.yaml
@@ -19,6 +19,23 @@ uplinkDecoder:
           - wind:
               speed: 16.4608
               direction: 0
+              elevation: 200
+    - description: 19 knots from the West at 5 meters
+      hardwareVersions: ['1.0-5M']
+      input:
+        fPort: 1
+        bytes: [3, 19]
+      output:
+        data:
+          direction: 'W'
+          speed: 19
+      # Normalized output, uses the normalizeUplink function (optional)
+      normalizedOutput:
+        data:
+          - wind:
+              speed: 9.7736
+              direction: 270
+              elevation: 500
     - description: 42 knots from the East
       input:
         fPort: 1

--- a/vendor/example/windsensor-codec.yaml
+++ b/vendor/example/windsensor-codec.yaml
@@ -4,7 +4,8 @@ uplinkDecoder:
   fileName: windsensor.js
   # Examples (optional)
   examples:
-    - description: 32 knots from the North
+    - description: 32 knots from the North at 2 meters
+      hardwareVersions: ['1.0-2M']
       input:
         fPort: 1
         bytes: [0, 32]

--- a/vendor/example/windsensor.js
+++ b/vendor/example/windsensor.js
@@ -25,12 +25,22 @@ function decodeUplink(input) {
 }
 
 function normalizeUplink(input) {
+  const direction = degrees[input.data.direction]; // letter to degrees
+  const speed = input.data.speed * 0.5144; // knots to m/s
+  // There are two hardware versions; one that has measures at 2 meters and the others 5 meters above the ground.
+  // Elevation in the normalized payload is in centimeters.
+  const elevation = {
+    '1.0-2M': 200,
+    '1.0-5M': 500,
+  }[input.version.hardwareVersion];
+
   return {
     // Normalized data
     data: {
       wind: {
-        direction: degrees[input.data.direction], // letter to degrees
-        speed: input.data.speed * 0.5144, // knots to m/s
+        direction,
+        speed,
+        elevation,
       },
     },
   };

--- a/vendor/example/windsensor.yaml
+++ b/vendor/example/windsensor.yaml
@@ -1,11 +1,11 @@
 name: Wind Sensor
 description: Wind Sensor with controllable LED
 
-# Hardware versions (optional, use when you have revisions)
+# Hardware versions (optional, use when you have revisions or different hardware features)
 hardwareVersions:
-  - version: '1.0'
+  - version: '1.0-2M' # Measures 2 meters from the ground
     numeric: 1
-  - version: '1.0-rev-A'
+  - version: '1.0-5M' # Measures 5 meters from the ground
     numeric: 2
 
 # Firmware versions (at least one is mandatory)
@@ -15,7 +15,8 @@ firmwareVersions:
     numeric: 1
     # Corresponding hardware versions (optional)
     hardwareVersions:
-      - '1.0'
+      - '1.0-2M'
+      - '1.0-5M'
 
     # Firmware features (optional)
     # Valid values are: remote rejoin (trigger a join from the application layer), transmission interval (configure how
@@ -47,7 +48,7 @@ firmwareVersions:
     version: '2.0'
     numeric: 2
     hardwareVersions:
-      - '1.0-rev-A'
+      - '1.0-5M'
     profiles:
       EU863-870:
         id: windsensor-profile


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #395 
Preparations for https://github.com/TheThingsNetwork/lorawan-stack/issues/5759

cc @pablojimpas

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `elevation` to normalized `wind`
- Add `version` object to `normalizeUplink()` input, with information (and terminology) used in the Device Repository
- Extend `example` with how this can be used
- Allow for validating a single vendor

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Review everything but last commit; that's just making sure everything is executed sequentially. It's slower, but it means less open file descriptors (because of concurrently running validation processes). Occassionally too many open file descriptors resulted in validation failure.