### PR TITLE
add codec to definition file

### DIFF
--- a/vendor/the-things-industries/generic-node-sensor-edition.yaml
+++ b/vendor/the-things-industries/generic-node-sensor-edition.yaml
@@ -10,9 +10,11 @@ firmwareVersions:
       EU863-870:
         id: generic-node-sensor-edition-868
         lorawanCertified: false
+        codec: generic-node-sensor-edition-codec
       US902-928:
         id: generic-node-sensor-edition-915
         lorawanCertified: false
+        codec: generic-node-sensor-edition-codec
 sensors:
   - accelerometer
   - battery


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
Added the `codec: name of codec file` to the End device definition file that was missing, which caused the payload formatter to not show up.

#### Changes
- Added `codec: generic-node-sensor-edition-codec to the End device definition file
