### PR TITLE
Generic Node description updates

### DIFF
--- a/vendor/the-things-industries/generic-node-sensor-edition-868.yaml
+++ b/vendor/the-things-industries/generic-node-sensor-edition-868.yaml
@@ -1,8 +1,8 @@
 vendorProfileID: 1
 supportsClassB: false
 supportsClassC: false
-macVersion: 1.0.2
-regionalParametersVersion: RP001-1.0.2-RevB
+macVersion: 1.0.3
+regionalParametersVersion: RP001-1.0.3-RevA
 supportsJoin: true
 maxEIRP: 16
 supports32bitFCnt: true

--- a/vendor/the-things-industries/generic-node-sensor-edition-915.yaml
+++ b/vendor/the-things-industries/generic-node-sensor-edition-915.yaml
@@ -1,8 +1,8 @@
 vendorProfileID: 2
 supportsClassB: false
 supportsClassC: false
-macVersion: 1.0.2
-regionalParametersVersion: RP001-1.0.2-RevB
+macVersion: 1.0.3
+regionalParametersVersion: RP001-1.0.3-RevA
 supportsJoin: true
 maxEIRP: 27
 supports32bitFCnt: true

--- a/vendor/the-things-industries/generic-node-sensor-edition-codec.js
+++ b/vendor/the-things-industries/generic-node-sensor-edition-codec.js
@@ -1,7 +1,7 @@
 function decodeUplink(input) {
   var data = {};
   data.batt_volt = input.bytes[0] / 10;
-  data.temperature = ((input.bytes[1] << 8) + input.bytes[2]) / 10 - 50;
+  data.temperature = ((input.bytes[1] << 8) + input.bytes[2] - 500) / 10;
   data.humidity = ((input.bytes[3] << 8) + input.bytes[4]) / 10;
 
   return {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR updates the GNSE to be marked as LoRaWAN 1.0.3, instead of 1.0.2b, since the underlying LoRaMac-node is actually supporting 1.0.3. The main gain here is that we gain the `CFList` in the US915 band.

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix GNSE payload decoder such that temperature calculations round properly.
- Use LoRaWAN 1.0.3 for GNSE.