### PR TITLE
Update vaqao-plus-sensor.js

### DIFF
--- a/vendor/nke-watteco/vaqao-plus-sensor.js
+++ b/vendor/nke-watteco/vaqao-plus-sensor.js
@@ -422,7 +422,7 @@ function bytes2Float32(bytes) {
       return sign * 0.0
     }
     exponent = -126
-    significand /= 1 << 22
+    significand /= 1 << 23
   } 
   else {
     significand = (significand | (1 << 23)) / (1 << 23)
@@ -787,7 +787,7 @@ function Bytes2Float32(bytes) {
   if (exponent == -127) {
     if (significand == 0) return sign * 0.0;
       exponent = -126;
-      significand /= (1 << 22);
+      significand /= (1 << 23);
     } 
     else significand = (significand | (1 << 23)) / (1 << 23);
 


### PR DESCRIPTION
fixe problem on Bytes2Float32 function. If exponent was -127 (no exponent) then the mantyss (significand) was bad calculated.

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

...

#### Changes
<!-- What are the changes made in this pull request? -->

- ...
- ...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.

Always mention changes in API.
-->

- ...
