### PR TITLE
add minol-zenner vendor and edc module definitions

### DIFF
--- a/vendor/minol-zenner/edc-communication-module-codec.yaml
+++ b/vendor/minol-zenner/edc-communication-module-codec.yaml
@@ -8,7 +8,7 @@ uplinkDecoder:
     - description: example meter values with status bytes
       input:
         fPort: 1
-        bytes: [27,00,00,00,0c,00,00,00,0d,00,00,00,0f]
+        bytes: [27, 00, 00, 00, 0c, 00, 00, 00, 0d, 00, 00, 00, 0f]
       output:
         data:
           removal_detection: 1,
@@ -16,4 +16,4 @@ uplinkDecoder:
           battery_end_of_life: 1,
           hw_error: 0,
           coil_manipulation: 1,
-          meter_values: [ 12, 13, 15 ]
+          meter_values: [12, 13, 15]

--- a/vendor/minol-zenner/edc-communication-module-codec.yaml
+++ b/vendor/minol-zenner/edc-communication-module-codec.yaml
@@ -1,0 +1,19 @@
+# Uplink decoder decodes binary data uplink into a JSON object (optional)
+# For documentation on writing encoders and decoders, see: https://www.thethingsindustries.com/docs/integrations/payload-formatters/javascript/
+uplinkDecoder:
+  fileName: edc-communication-module.js
+
+  # Examples
+  examples:
+    - description: example meter values with status bytes
+      input:
+        fPort: 1
+        bytes: [27,00,00,00,0c,00,00,00,0d,00,00,00,0f]
+      output:
+        data:
+          removal_detection: 1,
+          battery_low: 1,
+          battery_end_of_life: 1,
+          hw_error: 0,
+          coil_manipulation: 1,
+          meter_values: [ 12, 13, 15 ]

--- a/vendor/minol-zenner/edc-communication-module-codec.yaml
+++ b/vendor/minol-zenner/edc-communication-module-codec.yaml
@@ -8,12 +8,12 @@ uplinkDecoder:
     - description: example meter values with status bytes
       input:
         fPort: 1
-        bytes: [27, 00, 00, 00, 0c, 00, 00, 00, 0d, 00, 00, 00, 0f]
+        bytes: [0x27, 0x00, 0x00, 0x00, 0x0C, 0x00, 0x00, 0x00, 0x0D, 0x00, 0x00, 0x00, 0x0F]
       output:
         data:
-          removal_detection: 1,
-          battery_low: 1,
-          battery_end_of_life: 1,
-          hw_error: 0,
-          coil_manipulation: 1,
+          removal_detection: 1
+          battery_low: 1
+          battery_end_of_life: 1
+          hw_error: 0
+          coil_manipulation: 1
           meter_values: [12, 13, 15]

--- a/vendor/minol-zenner/edc-communication-module-profile.yaml
+++ b/vendor/minol-zenner/edc-communication-module-profile.yaml
@@ -1,7 +1,7 @@
 # Vendor profile ID, can be freely issued by the vendor
 # This vendor profile ID is also used on the QR code for LoRaWAN devices, see
 # https://lora-alliance.org/sites/default/files/2020-10/LoRa_Alliance_Vendor_ID_for_QR_Code.pdf
-vendorProfileID: 474
+vendorProfileID: 1
 
 # LoRaWAN MAC version: 1.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4 or 1.1
 macVersion: '1.0.3'

--- a/vendor/minol-zenner/edc-communication-module-profile.yaml
+++ b/vendor/minol-zenner/edc-communication-module-profile.yaml
@@ -1,0 +1,21 @@
+# Vendor profile ID, can be freely issued by the vendor
+# This vendor profile ID is also used on the QR code for LoRaWAN devices, see
+# https://lora-alliance.org/sites/default/files/2020-10/LoRa_Alliance_Vendor_ID_for_QR_Code.pdf
+vendorProfileID: 474
+
+# LoRaWAN MAC version: 1.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4 or 1.1
+macVersion: '1.0.3'
+regionalParametersVersion: 'RP001-1.0.3-RevA'
+
+# Whether the end device supports join (OTAA) or not (ABP)
+supportsJoin: true
+
+# Maximum EIRP
+maxEIRP: 16
+
+# Whether the end device supports 32-bit frame counters
+supports32bitFCnt: true
+
+# Whether the end device supports class B
+supportsClassB: false
+supportsClassC: false

--- a/vendor/minol-zenner/edc-communication-module.js
+++ b/vendor/minol-zenner/edc-communication-module.js
@@ -1,0 +1,26 @@
+function decodeUplink(input) {
+  var bytes = input.bytes;
+  var status = bytes[0]; // Assuming the first byte contains the status summary bits
+  var data = {
+    removal_detection: (status & 0x01) >> 0,
+    battery_low: (status & 0x02) >> 1,
+    battery_end_of_life: (status & 0x04) >> 2,
+    hw_error: (status & 0x08) >> 3,
+    coil_manipulation: (status & 0x20) >> 5,
+    // ... other status bits
+  };
+
+  // Assuming the next bytes contain meter values in SP12 format
+  var meterValues = [];
+  for (var i = 1; i < bytes.length; i += 4) {
+    // Combining four bytes to form a meter value
+    var meterValue = (bytes[i] << 24) | (bytes[i + 1] << 16) | (bytes[i + 2] << 8) | bytes[i + 3];
+    meterValues.push(meterValue);
+  }
+
+  data.meter_values = meterValues;
+
+  return {
+    data: data,
+  };
+}

--- a/vendor/minol-zenner/edc-communication-module.yaml
+++ b/vendor/minol-zenner/edc-communication-module.yaml
@@ -19,7 +19,7 @@ firmwareVersions:
     # Valid values are: remote rejoin (trigger a join from the application layer), transmission interval (configure how
     # often he device sends a message).
     #features:
-    
+
     profiles:
       EU863-870:
         # Identifier of the profile (lowercase, alphanumeric with dashes, max 36 characters)

--- a/vendor/minol-zenner/edc-communication-module.yaml
+++ b/vendor/minol-zenner/edc-communication-module.yaml
@@ -1,0 +1,28 @@
+name: EDC COMMUNICATION MODULE FOR WATER METERS
+description: The EDC communication module is an add-on module for water meters for secure remote reading and for integrating water meters into smart metering systems
+
+# Hardware versions (optional, use when you have revisions)
+hardwareVersions:
+  - version: '1.0'
+    numeric: 1
+
+# Firmware versions (at least one is mandatory)
+firmwareVersions:
+  - # Firmware version
+    version: '2.02.0'
+    numeric: 1
+    # Corresponding hardware versions (optional)
+    hardwareVersions:
+      - '1.0'
+
+    # Firmware features (optional)
+    # Valid values are: remote rejoin (trigger a join from the application layer), transmission interval (configure how
+    # often he device sends a message).
+    #features:
+    
+    profiles:
+      EU863-870:
+        # Identifier of the profile (lowercase, alphanumeric with dashes, max 36 characters)
+        id: edc-communication-module-profile
+        lorawanCertified: true
+        codec: edc-communication-module-codec

--- a/vendor/minol-zenner/index.yaml
+++ b/vendor/minol-zenner/index.yaml
@@ -1,0 +1,3 @@
+endDevices:
+  # Unique identifier of the end device (lowercase, alphanumeric with dashes, max 36 characters)
+  - edc-communication-module # look in edc-communication-module.yaml for the end device definition


### PR DESCRIPTION
#### Summary
this adds the minola-zenner vendor folder and a first version of the edc communications module with a fitting decoder.

#### Changes
- minola-zenner vendor added
- edc communication module profile and decoder added

#### Notes for Reviewers
- make validate ran only when removing "vendor/example" folder temporarily due to a failure in the image checking utility