### PR TITLE
Fix device weight set as hugo front matter weight

### DIFF
--- a/website/layouts/devices/single.html
+++ b/website/layouts/devices/single.html
@@ -53,7 +53,7 @@
           </div>
           <div class="item-6 item-xs-12">
             <ul>
-              {{with .Params.weight}}<li><b>Weight:</b> {{ . }} grams</li>{{ end }}
+              {{with .Params.deviceweight}}<li><b>Weight:</b> {{ . }} grams</li>{{ end }}
               {{with .Params.codecs}}<li><b>Frequency plans: </b>{{ range $key, $value := . }}<a
                   href="{{ $siteUrl }}/tags/{{ lower $key }}">{{ $key }}</a> {{ end }}</li>{{ end }}
             </ul>

--- a/website/tools/build/pkg/devicerepository/devicerepository.go
+++ b/website/tools/build/pkg/devicerepository/devicerepository.go
@@ -73,8 +73,9 @@ type EndDevice struct {
 		Diameter float32 `yaml:"diameter"`
 		Length   float32 `yaml:"length"`
 	} `yaml:"dimensions"`
-	Weight  float32 `yaml:"weight"`
-	Battery *struct {
+	Weight       float32 `yaml:"weight"`
+	DeviceWeight float32
+	Battery      *struct {
 		Replaceable bool   `yaml:"replaceable"`
 		Type        string `yaml:"type"`
 	} `yaml:"battery"`

--- a/website/tools/build/pkg/hugo/hugo.go
+++ b/website/tools/build/pkg/hugo/hugo.go
@@ -129,6 +129,8 @@ func CreateContentSingleDevice(dir config.Dir, drs devicerepository.Store) error
 			endDeviceModel.Vendor = vendor
 			endDeviceModel.Title = endDeviceModel.Name
 			endDeviceModel.Tags = generateTags(endDeviceModel)
+			endDeviceModel.DeviceWeight = endDeviceModel.Weight
+			endDeviceModel.Weight = 1
 
 			if endDeviceModel.Photos != nil && endDeviceModel.Photos.Main != "" {
 				PhotoMain := Photo{FileName: filepath.Base(endDeviceModel.Photos.Main), Path: endDeviceModel.Photos.Main}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

The ordering of the devices was based accidentally by weight.

#### Changes
<!-- What are the changes made in this pull request? -->

- Set current weight to deviceWeight.
- Set all weight fields to 1.


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@Jaime-Trinidad Found while working on the new filters and sorting, more to come soon. The next steps here is for us to use this `weight` field for custom (`featured`)  ordering of device. I'm thinking we make a json object with custom weights for select products. You will then have control over what is featured

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.

Always mention changes in API.
-->

- ...
