### PR TITLE
Added IN and AS regions to busylight device

### DIFF
--- a/vendor/plenom/busylight.yaml
+++ b/vendor/plenom/busylight.yaml
@@ -37,6 +37,14 @@ firmwareVersions:
         id: busylight-profile
         lorawanCertified: true
         codec: busylight-codec
+      AS923:
+        id: busylight-profile
+        lorawanCertified: true
+        codec: busylight-codec
+      IN865-867:
+        id: busylight-profile
+        lorawanCertified: true
+        codec: busylight-codec
 
 # Sensors that this device features (optional)
 # Valid values are:


### PR DESCRIPTION
	modified:   busylight.yaml
        Added IN and AS regions

#### Summary
The Busylight device does now support AS923 and IN865-867 regions
#### Changes
- Added AS923 region
- Added IN865-867 region

#### Checklist for Reviewers
<!-- Guidelines to follow when reviewing pull request -->

- [ ] Title and description should be descriptive (Not just a serial number for example).
- [ ] `vendorProfileID` should not be `vendorID`.
- [ ] All devices should be listed in the vendor's `index.yaml` file.
- [ ] At least 1 image per device and should be transparent.

#### Notes for Reviewers

#### Release Notes
