### PR TITLE
Fix vendorProfileID validation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,7 @@ Closes #0000, References #0000, etc.
 - [ ] Title and description should be descriptive (Not just a serial number for example).
 - [ ] `profileIDs` should not be `vendorID` and should be a unique value for every profile.
 - [ ] All devices should be listed in the vendor's `index.yaml` file.
+- [ ] Firmware versions can not be changed.
 - [ ] At least 1 image per device and should be transparent.
 
 #### Notes for Reviewers

--- a/bin/validate.js
+++ b/bin/validate.js
@@ -342,7 +342,7 @@ vendors.vendors.forEach((v) => {
 
           if (!vendorProfiles[vendorID][regionProfile.id]) {
             const profile = yaml.load(fs.readFileSync(`./vendor/${vendorID}/${regionProfile.id}.yaml`));
-            if (profile.vendorProfileID) {
+            if ('vendorProfileID' in profile) {
               console.log(`\n${key}: vendorProfileID exists. This method has been replaced with VendorIDs, see:`);
               console.log(`https://github.com/TheThingsNetwork/lorawan-devices?tab=readme-ov-file#vendor-device-index`);
               process.exit(1);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

I noticed with #782 that the validation wasn't catching if `vendorProfileID` existed. I am not sure why, since it can clearly read the value, but replacing it with catching the string does the trick (and I tested it, it works)

Also they tried to change the firmware versions, which gave us a lot of problems not long ago with Dragino, so updating the pull request template too.

#### Changes
<!-- What are the changes made in this pull request? -->

- change `if (profile.vendorProfileID)` to `if ('vendorProfileID' in profile)`
- Update pull request template with firmware versions


