### PR TITLE
Reenable Laird RS1xx 1W Ext Temperature variant

### DIFF
--- a/vendor/laird/rs1xx-ext-temp-1w-sensor.yaml
+++ b/vendor/laird/rs1xx-ext-temp-1w-sensor.yaml
@@ -22,19 +22,19 @@ firmwareVersions:
         # Unique identifier of the profile (lowercase, alphanumeric with dashes, max 36 characters)
         id: rs1xx-sensor-profile
         lorawanCertified: false
-        #codec: rs1xx-ext-temp-1w-sensor-codec
+        codec: rs1xx-ext-temp-1w-sensor-codec
       US902-928:
         id: rs1xx-sensor-profile
         lorawanCertified: false
-        #codec: rs1xx-ext-temp-1w-sensor-codec
+        codec: rs1xx-ext-temp-1w-sensor-codec
       AU915-928:
         id: rs1xx-sensor-profile
         lorawanCertified: false
-        #codec: rs1xx-ext-temp-1w-sensor-codec
+        codec: rs1xx-ext-temp-1w-sensor-codec
       AS923:
         id: rs1xx-sensor-profile
         lorawanCertified: false
-        #codec: rs1xx-ext-temp-1w-sensor-codec
+        codec: rs1xx-ext-temp-1w-sensor-codec
 
 # Sensors that this device features (optional)
 # Valid values are: accelerometer, altitude, auxiliary, barometer, battery, button, co2, distance, dust, gps, gyroscope,


### PR DESCRIPTION
#### Summary
Re-enables the Laird RS1xx 1 Wire External Temperature Probe variant.

#### Changes
Uncomments codec YAML references.

#### Checklist for Reviewers
<!-- Guidelines to follow when reviewing pull request, please do not remove. -->

- [ ] Title and description should be descriptive (Not just a serial number for example).
- [ ] `profileIDs` should not be `vendorID` and should be a unique value for every profile.
- [ ] All devices should be listed in the vendor's `index.yaml` file.
- [ ] Firmware versions can not be changed.
- [ ] At least 1 image per device and should be transparent.

#### Notes for Reviewers
Need to check with Johann if time out issues have been resolved.

#### Release Notes
Re-enabled Laird RS1xx 1 Wire External Temperature Probe variant.