### PR TITLE
Leak state typo fixed

### DIFF
--- a/vendor/quandify/cubicmeter-1-1-uplink.js
+++ b/vendor/quandify/cubicmeter-1-1-uplink.js
@@ -30,8 +30,8 @@ var responseTypes = {
 /* Smaller water leakages only availble when using Quandify platform API
 as it requires cloud analytics */
 var leakStates = {
-  2: 'medium',
-  3: 'large',
+  3: 'medium',
+  4: 'large',
 };
 
 var pipeTypes = {


### PR DESCRIPTION
#### Summary
A mixup in the leak state string has been fixed.

#### Changes
- Medium and Large leak text representation is now matching the leak state

#### Checklist for Reviewers
<!-- Guidelines to follow when reviewing pull request, please do not remove. -->

- [ ] Title and description should be descriptive (Not just a serial number for example).
- [ ] `profileIDs` should not be `vendorID` and should be a unique value for every profile.
- [ ] All devices should be listed in the vendor's `index.yaml` file.
- [ ] Firmware versions can not be changed.
- [ ] At least 1 image per device and should be transparent.

#### Notes for Reviewers
No breaking changes and only affects normalizedUplink

#### Release Notes
CubicMeter 1.1 Leak string fix