### PR TITLE
Removed unused functions crashing the decoder

### DIFF
--- a/vendor/quandify/cubicmeter-1-1-copper.yaml
+++ b/vendor/quandify/cubicmeter-1-1-copper.yaml
@@ -1,5 +1,5 @@
 name: CubicMeter 1.1 Copper
-description: Non-invasive water meter and leakage sensor
+description: Clamp-on water flow meter and leak sensor.
 
 # Hardware versions (optional)
 hardwareVersions:

--- a/vendor/quandify/cubicmeter-1-1-plastic.yaml
+++ b/vendor/quandify/cubicmeter-1-1-plastic.yaml
@@ -1,5 +1,5 @@
 name: CubicMeter 1.1 Plastic
-description: Non-invasive water meter and leakage sensor
+description: Clamp-on water flow meter and leak sensor.
 
 # Hardware versions (optional)
 hardwareVersions:

--- a/vendor/quandify/cubicmeter-1-1-uplink.js
+++ b/vendor/quandify/cubicmeter-1-1-uplink.js
@@ -277,26 +277,6 @@ var normalizeUplink = function (input) {
   };
 };
 
-// Convert a hex string to decimal array
-var hexToDecArray = function (hexString) {
-  const size = 2;
-  const length = Math.ceil(hexString.length / size);
-  const decimalList = new Array(length);
-
-  for (let i = 0, o = 0; i < length; ++i, o += size) {
-    decimalList[i] = parseInt(hexString.substr(o, size), 16);
-  }
-
-  return decimalList;
-};
-
-var base64ToDecArray = function (base64String) {
-  const buffer = Buffer.from(base64String, 'base64');
-  const bufString = buffer.toString('hex');
-
-  return hexToDecArray(bufString);
-};
-
 var decArrayToStr = function (byteArray) {
   return Array.from(byteArray, function (byte) {
     return ('0' + (byte & 0xff).toString(16)).slice(-2).toUpperCase();


### PR DESCRIPTION
#### Summary
Removed unused functions that were accidentally causing the decoder to crash.

#### Changes
Removed unused functions 
- hexToDecArray
- base64ToDecArray

#### Checklist for Reviewers
<!-- Guidelines to follow when reviewing pull request, please do not remove. -->

- [ ] Title and description should be descriptive (Not just a serial number for example).
- [ ] `profileIDs` should not be `vendorID` and should be a unique value for every profile.
- [ ] All devices should be listed in the vendor's `index.yaml` file.
- [ ] Firmware versions can not be changed.
- [ ] At least 1 image per device and should be transparent.

#### Notes for Reviewers

#### Release Notes
