### PR TITLE
[fix] vendor/st/nucleo-wl55jc: unit of barometric pressure should be in hPa

### DIFF
--- a/vendor/stmicroelectronics/nucleo-wl55jc-codec.yaml
+++ b/vendor/stmicroelectronics/nucleo-wl55jc-codec.yaml
@@ -20,7 +20,7 @@ uplinkDecoder:
             value: 'ON'
           pressure:
             displayName: Barometric pressure
-            unit: Pa
+            unit: hPa
             value: 1000.0
           temperature:
             displayName: Internal temperature

--- a/vendor/stmicroelectronics/nucleo-wl55jc.js
+++ b/vendor/stmicroelectronics/nucleo-wl55jc.js
@@ -18,7 +18,7 @@ function decodeUplink(input) {
       };
       data.pressure = {
         displayName: 'Barometric pressure',
-        unit: 'Pa',
+        unit: 'hPa',
         value: ((input.bytes[1] << 8) + input.bytes[2]) / 10
       };
       data.temperature = {


### PR DESCRIPTION
#### Summary
Fix: Unit of barometric pressure should be hPa (not Pa) for ST NUCLEO-WL55JC.

#### Changes
Fixed unit of barometric pressure to be hPa (not Pa) for ST NUCLEO-WL55JC.

#### Checklist for Reviewers
<!-- Guidelines to follow when reviewing pull request, please do not remove. -->

- [x] Title and description should be descriptive (Not just a serial number for example).
- [x] `profileIDs` should not be `vendorID` and should be a unique value for every profile.
- [x] All devices should be listed in the vendor's `index.yaml` file.
- [x] Firmware versions can not be changed.
- [x] At least 1 image per device and should be transparent.