### PR TITLE
MClimate HT - Fix temperature decoding issue

### DIFF
--- a/vendor/mclimate/ht-sensor.js
+++ b/vendor/mclimate/ht-sensor.js
@@ -12,7 +12,7 @@ function decodeUplink(input) {
 		}
 
 		function handleKeepalive(bytes, data){
-			var tempHex = '0' + bytes[1].toString(16) + bytes[2].toString(16);
+			var tempHex = ("0" + bytes[1].toString(16)).substr(-2) + ("0" + bytes[2].toString(16)).substr(-2);
 			var tempDec = parseInt(tempHex, 16);
 			var temperatureValue = calculateTemperature(tempDec);
 			var humidityValue = calculateHumidity(bytes[3]);


### PR DESCRIPTION
#### Summary
The sensorTemperature from HT sensors is decoded wrong in the official MClimate codec.
I have sent them an email in march of this year with the proposed correction, but had no response from them.

Basically, with the official codec (as well as the current version in this repo), between the following ranges, the sensorTemperature has an offset of -48°C
- -40°C to -38.5°C
- -14.4°C to -12.9°C
- 11.2°C to 12.7°C
- 36.8°C to 38.3°C

...and so on for a range of 1.5°C every 24°C.

#### Changes
The 4 bytes composing the temperature are now decoded correctly. 

If we take the example byte payload : `010204a1d60400`
The bytes "0204" (which correspond to a temperature of 11.6 °C) are stored as `024` instead of `0204` in the "tempHex" variable, which decodes it to -36.4°C.


@MClimate - I encourage you guys to apply those corrections on your official documentation (the Chirpstack/TTN examples are not up to date)


#### Checklist for Reviewers
<!-- Guidelines to follow when reviewing pull request, please do not remove. -->

- [ ] Title and description should be descriptive (Not just a serial number for example).
- [ ] `profileIDs` should not be `vendorID` and should be a unique value for every profile.
- [ ] All devices should be listed in the vendor's `index.yaml` file.
- [ ] Firmware versions can not be changed.
- [ ] At least 1 image per device and should be transparent.