### PR TITLE
Fix profile ID for yobiiq sd-1001

### DIFF
--- a/vendor/yobiiq/index.yaml
+++ b/vendor/yobiiq/index.yaml
@@ -7,7 +7,7 @@ endDevices:
 # It can either be a combo of device ID + hardware version + firmware version + region, or profile ID + codec ID
 # NOTE: The profileIDs is different from the vendorID.
 profileIDs:
-  '04154EB7':
+  '20151':
     endDeviceID: 'sd-1001'
     firmwareVersion: '1.0'
     hardwareVersion: '1.0'


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix profile ID for yobiiq sd-1001. We missed this in https://github.com/TheThingsNetwork/lorawan-devices/pull/840 @dhakke 

#### Changes
<!-- What are the changes made in this pull request? -->

- Change profile ID for yobiiq sd-1001 from `'04154EB7` to `20151` (`0x4EB7` in base10).  

#### Checklist for Reviewers
<!-- Guidelines to follow when reviewing pull request, please do not remove. -->

- [ ] Title and description should be descriptive (Not just a serial number for example).
- [ ] `profileIDs` should not be `vendorID` and should be a unique value for every profile.
- [ ] All devices should be listed in the vendor's `index.yaml` file.
- [ ] Firmware versions can not be changed.
- [ ] At least 1 image per device and should be transparent.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Vendor Profile IDs are 2 byte values as per TR005 and TTS interprets these values as base10.

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.

Always mention changes in API.
-->

- Fix profile ID for yobiiq sd-1001
