### PR TITLE
Added payload formatter for new high brightness devices

### DIFF
--- a/vendor/plenom/busylight.js
+++ b/vendor/plenom/busylight.js
@@ -22,30 +22,6 @@ function decodeUplink(input) {
   }
   else if (input.bytes.length == 25)
   {
-    switch (input.bytes[24])
-    {
-      case 0x01:
-        reason="Power On Reset";
-        break;
-      case 0x02:
-        reason="Brownout 1.2V";
-        break;
-      case 0x04:
-        reason="Brownout 3.3V";
-        break;
-      case 0x10:
-        reason="External Reset";
-        break;
-      case 0x20:
-        reason="WatchDog Timer triggered";
-        break;
-      case 0x40:
-        reason="Software";
-        break;
-      case 0x80:
-        reason="Backup";
-        break;
-    }
   return {
     data: {
       RSSI: byteArrayToLong(input.bytes, 0),
@@ -60,7 +36,7 @@ function decodeUplink(input) {
       sw_rev: input.bytes[21],
       hw_rev: input.bytes[22],
       adr_state: input.bytes[23],
-      last_reset_reason: reason
+      high_brightness_mode: input.bytes[24]
     },
     warnings: [],
     errors: []
@@ -76,7 +52,7 @@ return {
       lastcolor_green: input.bytes[6],
       lastcolor_ontime: input.bytes[7],
       lastcolor_offtime: input.bytes[8],
-      last_reset_reason: input.bytes[9]
+      high_brightness_mode: input.bytes[9]
     },
     warnings: [],
     errors: []


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
The upcoming new devices will have a brighter LED.
To maintain compatibility to the current devices, they are shipped with low brightness configured.
We have added a flag to indicate if the device is running in low or high intensity mode
...

#### Changes
<!-- What are the changes made in this pull request? -->

- removed debugging info from payload formatter
- added brightness flag to payload formatter

#### Checklist for Reviewers
<!-- Guidelines to follow when reviewing pull request, please do not remove. -->

- [ ] Title and description should be descriptive (Not just a serial number for example).
- [ ] `profileIDs` should not be `vendorID` and should be a unique value for every profile.
- [ ] All devices should be listed in the vendor's `index.yaml` file.
- [ ] Firmware versions can not be changed.
- [ ] At least 1 image per device and should be transparent.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.

Always mention changes in API.
-->

- ...
