### PR TITLE
Update radio_bridge_packet_decoder.js

### DIFF
--- a/vendor/radio-bridge/radio_bridge_packet_decoder.js
+++ b/vendor/radio-bridge/radio_bridge_packet_decoder.js
@@ -478,7 +478,18 @@ function Generic_Decoder(bytes , port) {
                 default: ThermocoupleEvent = "Undefined"; break;
             }
             // decode is across 16-bits
-            Temperature = parseInt(((bytes[3] * 256) + bytes[4]) / 16);
+            negativeNumber = 0xFFFF0000;
+            Temp16bits = ((bytes[3] << 8) | bytes[4]);
+
+            if(Temp16bits & 0x8000)
+            {
+              Temperature = (negativeNumber | Temp16bits)/16;
+            }
+            else
+            {
+              Temperature = Temp16bits/16;
+            }
+
             Faults = bytes[5];
             // decode each bit in the fault byte
             FaultColdOutsideRange = (Faults >> 7) & 0x01;


### PR DESCRIPTION
#### Summary
The current radio bridge decoder handles thermocouple events as a uint16 when it is a signed 16 bit number per https://multitech.com/wp-content/uploads/S000826_Radio-Bridge-LoRaWAN-Wireless-Sensors_User-Guide.pdf.

This caused issues where negative numbers looked like large positive numbers.

#### Changes
I added proper handling for a signed 16 bit variable.

#### Checklist for Reviewers
<!-- Guidelines to follow when reviewing pull request, please do not remove. -->

- [ ] Title and description should be descriptive (Not just a serial number for example).
- [ ] `profileIDs` should not be `vendorID` and should be a unique value for every profile.
- [ ] All devices should be listed in the vendor's `index.yaml` file.
- [ ] Firmware versions can not be changed.
- [ ] At least 1 image per device and should be transparent.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.

Always mention changes in API.
-->

- ...
