### PR TITLE
Fix Watteco SmartPilot Wire encoding

### DIFF
--- a/vendor/watteco/smartpilot-wire.yaml
+++ b/vendor/watteco/smartpilot-wire.yaml
@@ -1,5 +1,5 @@
 name: SmartPilot-Wire
-description: The WATTECO The SmartPilot Wire is a Class C LoRaWAN® actuator that monitors and controls up to 6 operating modes for any electric heater as well as any active load (ON/OFF) driven by a relay.
+description: The WATTECO The SmartPilot Wire is a Class C LoRaWANÂ® actuator that monitors and controls up to 6 operating modes for any electric heater as well as any active load (ON/OFF) driven by a relay.
 
 # Hardware versions (optional, use when you have revisions)
 hardwareVersions:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

There was a problem with encoding in one of the files which prevented the release.

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix encoding in `vendor/watteco/smartpilot-wire.yaml`

#### Checklist for Reviewers
<!-- Guidelines to follow when reviewing pull request, please do not remove. -->

- [ ] Title and description should be descriptive (Not just a serial number for example).
- [ ] `profileIDs` should not be `vendorID` and should be a unique value for every profile.
- [ ] All devices should be listed in the vendor's `index.yaml` file.
- [ ] Firmware versions can not be changed.
- [ ] At least 1 image per device and should be transparent.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I don't think GH shows the difference between the lines

<img width="949" alt="image" src="https://github.com/user-attachments/assets/39d64919-3377-4532-af42-3b87b9f18612" />

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.

Always mention changes in API.
-->

N/A
