### PR TITLE
Fixing typo in plenom busy light formatter

### DIFF
--- a/vendor/plenom/busylight.js
+++ b/vendor/plenom/busylight.js
@@ -111,7 +111,7 @@ else if (input.bytes.length == 6)
       blue: input.bytes[1],
       ontime: input.bytes[3],
       offtime: input.bytes[4],
-      immediate_uplink: input.byte[5]
+      immediate_uplink: input.bytes[5]
     },
     warnings: [],
     errors: []


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
This PR contains the fix to this issue that has been raised - https://github.com/TheThingsNetwork/lorawan-devices/issues/910

This issue is that the Plenom Busylights payload formatter, has been displaying the following error when trying to decode the downlink message: `TypeError: Cannot read property '5' of undefined at decodeDownlink (<eval>:115:35(77))`
...

#### Changes
In the previous code the `s` in bytes was missing, as it was trying to do `input.byte[5]` instead of  `input.bytes[5]` 

I have updated the code to resolve this typo.


#### Checklist for Reviewers
<!-- Guidelines to follow when reviewing pull request, please do not remove. -->

- [] Title and description should be descriptive (Not just a serial number for example).
- [] `profileIDs` should not be `vendorID` and should be a unique value for every profile.
- [] All devices should be listed in the vendor's `index.yaml` file.
- [] Firmware versions can not be changed.
- [] At least 1 image per device and should be transparent.


