### PR TITLE
Update KELLER rebranded naming

### DIFF
--- a/vendor/index.yaml
+++ b/vendor/index.yaml
@@ -340,8 +340,8 @@ vendors:
     vendorID: 220
 
   - id: keller
-    name: KELLER Druckmesstechnik AG
-    website: https://keller-druck.com/
+    name: KELLER Pressure
+    website: https://keller-pressure.com/
     logo: keller-logo.svg
     vendorID: 222
     description: KELLER Pressure, Europe's leading manufacturer of isolated pressure transducers and transmitters, was founded in 1974 by H. W. Keller, the inventor of the integrated silicon measuring cell. Piezoresitive pressure sensors have impressively high precision and pressure ranges from 5 mbar to 2000 bar. The KELLER product range includes digital manometers, level probes, data loggers and remote transmission units communicating wirelessly over LoRaWAN®, NB-IoT, LTE-M, LTE and more.

--- a/vendor/keller/adt1-box.yaml
+++ b/vendor/keller/adt1-box.yaml
@@ -33,7 +33,7 @@ firmwareVersions:
 # This device can be connected with various kind of KELLER pressure sensors including Level Probes and transmitters
 # The ADT1 itself measures humidity, battery capacity (0..100%), battery voltage, temperature and barometric pressure
 # The sensors attached measure pressure, temperature and optionally conductivity
-# https://docs.kolibricloud.ch/sending-technology/lora-technology/keller-lora-payload/
+# https://docs.pressuresuite.com/sending-technology/lora-technology/keller-lora-payload/
 sensors:
   - pressure
   - temperature
@@ -75,10 +75,10 @@ keyProvisioning:
 
 keySecurity: none
 
-#documentationURL: https://docs.kolibricloud.ch/sending-technology/lora-technology/
+#documentationURL: https://docs.pressuresuite.com/sending-technology/lora-technology/
 #githubURL: https://github.com/KELLERAGfuerDruckmesstechnik
-productURL: https://keller-druck.com/en/products/data-loggers/remote-transmission-units-with-data-logger/adt1-box
-dataSheetURL: https://download.keller-druck.com/api/download/q3sWTxfeyHkzDXiezeoXjj/en/2022-08.pdf
+productURL: https://keller-pressure.com/en/products/data-loggers/remote-transmission-units-with-data-logger/adt1-box
+dataSheetURL: https://download.keller-pressure.com/api/download/q3sWTxfeyHkzDXiezeoXjj/en/2025-05.pdf
 
 photos:
   main: adt1-box-open.jpg

--- a/vendor/keller/adt1-tube.yaml
+++ b/vendor/keller/adt1-tube.yaml
@@ -33,7 +33,7 @@ firmwareVersions:
 # This device can be connected with various kind of KELLER pressure sensors including Level Probes and transmitters
 # The ADT1 itself measures humidity, battery capacity (0..100%), battery voltage, temperature and barometric pressure
 # The sensors attached measure pressure, temperature and optionally conductivity
-# https://docs.kolibricloud.ch/sending-technology/lora-technology/keller-lora-payload/
+# https://docs.pressuresuite.com/sending-technology/lora-technology/keller-lora-payload/
 sensors:
   - pressure
   - temperature
@@ -74,10 +74,10 @@ keyProvisioning:
 
 keySecurity: none
 
-#documentationURL: https://docs.kolibricloud.ch/sending-technology/lora-technology/
+#documentationURL: https://docs.pressuresuite.com/sending-technology/lora-technology/
 #githubURL: https://github.com/KELLERAGfuerDruckmesstechnik
-productURL: https://keller-druck.com/en/products/data-loggers/remote-transmission-units-with-data-logger/adt1-tube
-dataSheetURL: https://download.keller-druck.com/api/download/q3sWTxfeyHkzDXiezeoXjj/en/2022-08.pdf
+productURL: https://keller-pressure.com/en/products/data-loggers/remote-transmission-units-with-data-logger/adt1-tube
+dataSheetURL: https://download.keller-pressure.com/api/download/q3sWTxfeyHkzDXiezeoXjj/en/2025-05.pdf
 
 photos:
   main: adt1-tube-open.jpg

--- a/vendor/keller/arc1-box.yaml
+++ b/vendor/keller/arc1-box.yaml
@@ -17,7 +17,7 @@ firmwareVersions:
 # This device can be connected with various kind of KELLER pressure sensors including Level Probes and transmitters
 # The ARC1 itself measures humidity, battery capacity (0..100%), battery voltage, temperature and barometric pressure
 # The sensors attached measure pressure, temperature and optionally conductivity
-# https://docs.kolibricloud.ch/sending-technology/lora-technology/keller-lora-payload/
+# https://docs.pressuresuite.com/sending-technology/lora-technology/keller-lora-payload/
 sensors:
   - pressure
   - temperature
@@ -59,11 +59,10 @@ keyProvisioning:
 
 keySecurity: none
 
-#documentationURL: https://docs.kolibricloud.ch/sending-technology/lora-technology/
+#documentationURL: https://docs.pressuresuite.com/sending-technology/lora-technology/
 #githubURL: https://github.com/KELLERAGfuerDruckmesstechnik
-#manualURL: https://download.keller-druck.com/api/download/6qEUnTrFjvSfezrFnzxGmb/en/2018-08.pdf
-productURL: https://keller-druck.com/en/products/wireless-solutions/remote-transmission-units/arc1-box
-dataSheetURL: https://download.keller-druck.com/api/download/VyyiKwTWpeTxLdpb9sSSK4/en/2021-01.pdf
+productURL: https://keller-pressure.com/en/products/wireless-solutions/remote-transmission-units/arc1-box
+dataSheetURL: https://download.keller-pressure.com/api/download/VyyiKwTWpeTxLdpb9sSSK4/en/2025-05.pdf
 
 photos:
   main: arc1-box-front.jpg

--- a/vendor/keller/arc1-tube.yaml
+++ b/vendor/keller/arc1-tube.yaml
@@ -17,7 +17,7 @@ firmwareVersions:
 # This device can be connected with various kind of KELLER pressure sensors including Level Probes and transmitters
 # The ARC1 itself measures humidity, battery capacity (0..100%), battery voltage, temperature and barometric pressure
 # The sensors attached measure pressure, temperature and optionally conductivity
-# https://docs.kolibricloud.ch/sending-technology/lora-technology/keller-lora-payload/
+# https://docs.pressuresuite.com/sending-technology/lora-technology/keller-lora-payload/
 sensors:
   - pressure
   - temperature
@@ -58,11 +58,10 @@ keyProvisioning:
 
 keySecurity: none
 
-#documentationURL: https://docs.kolibricloud.ch/sending-technology/lora-technology/
+#documentationURL: https://docs.pressuresuite.com/sending-technology/lora-technology/
 #githubURL: https://github.com/KELLERAGfuerDruckmesstechnik
-#manualURL: https://download.keller-druck.com/api/download/6qEUnTrFjvSfezrFnzxGmb/en/2018-08.pdf
-productURL: https://keller-druck.com/en/products/wireless-solutions/remote-transmission-units/arc1-tube
-dataSheetURL: https://download.keller-druck.com/api/download/VyyiKwTWpeTxLdpb9sSSK4/en/2021-01.pdf
+productURL: https://keller-pressure.com/en/products/wireless-solutions/remote-transmission-units/arc1-tube
+dataSheetURL: https://download.keller-pressure.com/api/download/VyyiKwTWpeTxLdpb9sSSK4/en/2025-05.pdf
 
 photos:
   main: arc1-tube.jpg

--- a/vendor/keller/keller-codec.yaml
+++ b/vendor/keller/keller-codec.yaml
@@ -1,8 +1,8 @@
 # The KELLER payload is a little bit complicated as the device can have one or many level probes or pressure transmitter
 # Therefore, a connection type defines the possible channels which again are mapped to physical units like pressure, temperature..
-# See protocol: https://docs.kolibricloud.ch/sending-technology/lora-technology/keller-lora-payload/
+# See protocol: https://docs.pressuresuite.com/sending-technology/lora-technology/keller-lora-payload/
 # and the decoder on github: https://github.com/KELLERAGfuerDruckmesstechnik/KellerAgTheThingsNetworkPayloadDecoder
-# The alternative is an open-source C# library that does the similar:  https://iotconverter.kolibricloud.ch/
+# The alternative is an open-source C# library that does the similar:  https://iotconverter.pressuresuite.com/
 uplinkDecoder:
   fileName: kellerpayload.js
   examples:

--- a/vendor/keller/kellerpayload.js
+++ b/vendor/keller/kellerpayload.js
@@ -1,4 +1,4 @@
-/* This is just a decoder for the TTN live viewer. The complete payload format protocol can be found here: https://docs.kolibricloud.ch/sending-technology/lora-technology/keller-lora-payload/*/
+/* This is just a decoder for the TTN live viewer. The complete payload format protocol can be found here: https://docs.pressuresuite.com/sending-technology/lora-technology/keller-lora-payload/*/
 /* This code is from https://github.com/KELLERAGfuerDruckmesstechnik/KellerAgTheThingsNetworkPayloadDecoder */
 
 function decodeUplink(input) {
@@ -36,7 +36,7 @@ function encodeDownlink(input) {
     data: {
       bytes: input.bytes
     },
-    warnings: ["Encoding of downlink is not supported by the JS decoder. Yet, it is possible to use downlink telegrams using the correct payload (https://docs.kolibricloud.ch/sending-technology/ADT1%20LoRa%20data%20communication%20protocol%2002_2020.pdf)"],
+    warnings: ["Encoding of downlink is not supported by the JS decoder. Yet, it is possible to use downlink telegrams using the correct payload (https://docs.pressuresuite.com/sending-technology/ADT1%20LoRa%20data%20communication%20protocol%2002_2020.pdf)"],
     errors: []
   }
 }
@@ -46,7 +46,7 @@ function decodeDownlink(input) {
     data: {
       bytes: input.bytes
     },
-    warnings: ["Decoding of downlink is not supported by the JS decoder. Yet, it is possible to use downlink telegrams using the correct payload (https://docs.kolibricloud.ch/sending-technology/ADT1%20LoRa%20data%20communication%20protocol%2002_2020.pdf)"],
+    warnings: ["Decoding of downlink is not supported by the JS decoder. Yet, it is possible to use downlink telegrams using the correct payload (https://docs.pressuresuite.com/sending-technology/ADT1%20LoRa%20data%20communication%20protocol%2002_2020.pdf)"],
     errors: []
   }
 }


### PR DESCRIPTION
Companies like to rebrand because of reasons. The engineers have to follow and adapt all the rebranding strings everywhere to fullfill the dreams and wishes of management, not offering a technical benefit.

#### Summary & Changes
We (KELLER) changed from 
 - KELLER Druckmesstechnik -> KELLER Pressure
 - www.keller-druck.com -> www.keller-pressure.com
 - KOLIBRI Cloud -> PressureSuite

Only strings and URLs have been replaced.


#### Checklist for Reviewers
- [ ] Pretty forward just changed strings
- [ ] `vendorID` is still 'keller'
- [ ] Name and website changed in [vendor/index.yaml](https://github.com/cBashTN/lorawan-devices/commit/badb8a7fc07bbcf8cacb36964f0ac9462f2f5917#diff-474943b7fb83f70053ac1c0009870de1aa966b524e43c5c97379edb363bac038)
- [ ] The rest are productURL & dataSheetURL in the keller yaml files

#### Notes for Reviewers
Please accept the change!

#### Release Notes
Officially use "Update KELLER rebranded naming"
