### PR TITLE
Set a hash function for Webpack

### DIFF
--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -35,7 +35,8 @@ module.exports = (env, argv) => {
         output: {
             path: path.resolve(__dirname, 'static/'),
             filename: `js/${isProduction ? '[hash].' : ''}[name].js`,
-            publicPath: BASE_PATH
+            publicPath: BASE_PATH,
+            hashFunction: 'sha512',
         },
         resolve: {
           alias: {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fixes [the following error](https://github.com/TheThingsNetwork/lorawan-devices/actions/runs/15824432900/job/44600958896). 
[Explanation](https://stackoverflow.com/a/73027407)

```
yarn run v1.22.22
$ webpack
node:internal/crypto/hash:79
  this[kHandle] = new _Hash(algorithm, xofLen, algorithmId, getHashCache());
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:79:19)
    at Object.createHash (node:crypto:139:10)
    at module.exports (/home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/webpack/lib/NormalModule.js:471:10)
    at /home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/webpack/lib/NormalModule.js:503:5
    at /home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/webpack/lib/NormalModule.js:358:12
    at /home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/loader-runner/lib/LoaderRunner.js:[21](https://github.com/TheThingsNetwork/lorawan-devices/actions/runs/15824432900/job/44600958896#step:9:22)4:10)
    at iterateNormalLoaders (/home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/loader-runner/lib/LoaderRunner.js:[22](https://github.com/TheThingsNetwork/lorawan-devices/actions/runs/15824432900/job/44600958896#step:9:23)1:10)
    at /home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/loader-runner/lib/LoaderRunner.js:[23](https://github.com/TheThingsNetwork/lorawan-devices/actions/runs/15824432900/job/44600958896#step:9:24)6:3
    at context.callback (/home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at /home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/babel-loader/lib/index.js:59:71 {
  opensslErrorStack: [
    'error:03000086:digital envelope routines::initialization error',
    'error:0308010C:digital envelope routines::unsupported'
  ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

Node.js v22.16.0
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.yarn run v1.22.22
$ webpack
node:internal/crypto/hash:79
  this[kHandle] = new _Hash(algorithm, xofLen, algorithmId, getHashCache());
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:79:19)
    at Object.createHash (node:crypto:139:10)
    at module.exports (/home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/webpack/lib/NormalModule.js:471:10)
    at /home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/webpack/lib/NormalModule.js:503:5
    at /home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/webpack/lib/NormalModule.js:358:12
    at /home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/loader-runner/lib/LoaderRunner.js:[21](https://github.com/TheThingsNetwork/lorawan-devices/actions/runs/15824432900/job/44600958896#step:9:22)4:10)
    at iterateNormalLoaders (/home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/loader-runner/lib/LoaderRunner.js:[22](https://github.com/TheThingsNetwork/lorawan-devices/actions/runs/15824432900/job/44600958896#step:9:23)1:10)
    at /home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/loader-runner/lib/LoaderRunner.js:[23](https://github.com/TheThingsNetwork/lorawan-devices/actions/runs/15824432900/job/44600958896#step:9:24)6:3
    at context.callback (/home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at /home/runner/work/lorawan-devices/lorawan-devices/website/node_modules/babel-loader/lib/index.js:59:71 {
  opensslErrorStack: [
    'error:03000086:digital envelope routines::initialization error',
    'error:0308010C:digital envelope routines::unsupported'
  ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

Node.js v22.16.0
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```