### PR TITLE
Add Lobaro TTN OneWire Test device (EU868) including basic codec

### DIFF
--- a/vendor/lobaro/index.yaml
+++ b/vendor/lobaro/index.yaml
@@ -1,0 +1,3 @@
+name: Lobaro
+endDevices:
+  - ttn_onewire_test

--- a/vendor/lobaro/ttn_onewire_test/codec.yaml
+++ b/vendor/lobaro/ttn_onewire_test/codec.yaml
@@ -1,0 +1,2 @@
+uplinkDecoder:
+  fileName: uplink.js

--- a/vendor/lobaro/ttn_onewire_test/index.yaml
+++ b/vendor/lobaro/ttn_onewire_test/index.yaml
@@ -1,0 +1,20 @@
+name: "TTN OneWire Test"
+description: "Testdevice with OneWire Sensor, EU868"
+hardwareVersions:
+  - version: "1.0"
+firmwareVersions:
+  - version: "1.0"
+    numeric: 1
+    profiles:
+      EU863-870:
+        id: onewire-eu868
+        lorawanCertified: false
+        codec: onewire
+profiles:
+  - id: onewire-eu868
+    lorawanVersion: "1.0.3"
+    regionalParametersVersion: "RP001-1.0.3-REV-A"
+    supportsJoin: true
+    macSettings:
+      rx1Delay: 5
+      supports32BitFCnt: true

--- a/vendor/lobaro/ttn_onewire_test/uplink.js
+++ b/vendor/lobaro/ttn_onewire_test/uplink.js
@@ -1,0 +1,9 @@
+function decodeUplink(input) {
+  if (!input.bytes || input.bytes.length < 2) {
+    return { errors: ["payload too short"] };
+  }
+  var raw = (input.bytes[0] << 8) | input.bytes[1];
+  if (raw & 0x8000) raw = raw - 0x10000;
+  var temperature = raw / 100.0;
+  return { data: { temperature_c: temperature } };
+}


### PR DESCRIPTION
Adds Lobaro Test device with OneWire temperature sensor:
- index.yaml with HW/FW
- EU868 profile
- basic uplink decoder