### PR TITLE
Build the website in CI, scoped away from vendor contributions

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -16,16 +16,12 @@ on:
       - master
     paths:
       - 'website/**'
-      - 'package.json'
-      - 'package-lock.json'
       - 'schema.json'
       - 'lib/**'
       - '.github/workflows/build-website.yml'
   pull_request:
     paths:
       - 'website/**'
-      - 'package.json'
-      - 'package-lock.json'
       - 'schema.json'
       - 'lib/**'
       - '.github/workflows/build-website.yml'
@@ -54,8 +50,6 @@ jobs:
         run: |
           cd website/
           make go.deps
-      - name: Install Node.js dependencies
-        run: npm ci
       - name: Build content
         run: |
           cd website/

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -1,0 +1,77 @@
+# The website is a downstream consumer of the device data in this repository,
+# not a gate on it: vendors contribute device YAML, codecs and images, and it
+# is not their responsibility to keep the Hugo site building. This workflow is
+# therefore scoped to the files the website build actually reads, so a pull
+# request that only touches vendor/ never triggers it -- an internal website
+# problem can never show up as a failure on a vendor's device submission.
+#
+# Vendor data reaching the site is still covered: the generator consumes
+# vendor/ during Release Device Repository on every push to master, which is
+# where such a break surfaces today.
+name: Build website
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'website/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'schema.json'
+      - 'lib/**'
+      - '.github/workflows/build-website.yml'
+  pull_request:
+    paths:
+      - 'website/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'schema.json'
+      - 'lib/**'
+      - '.github/workflows/build-website.yml'
+
+jobs:
+  build-website:
+    name: Build website
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '~1.24'
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.159.2'
+          extended: true
+      - name: Download Go dependencies
+        run: |
+          cd website/
+          make go.deps
+      - name: Install Node.js dependencies
+        run: npm ci
+      - name: Build content
+        run: |
+          cd website/
+          make go.build
+      - name: Build assets
+        run: |
+          cd website/
+          yarn install
+          yarn build
+        env:
+          BASE_URL: https://www.thethingsnetwork.org
+          BASE_PATH: /device-repository
+      - name: Build Hugo
+        run: |
+          cd website/
+          make hugo.build.public
+        env:
+          BASE_URL: https://www.thethingsnetwork.org
+          BASE_PATH: /device-repository

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -26,6 +26,9 @@ on:
       - 'lib/**'
       - '.github/workflows/build-website.yml'
 
+permissions:
+  contents: read
+
 jobs:
   build-website:
     name: Build website


### PR DESCRIPTION
**Updated after review feedback from @mjamescompton — the original version of this PR built the website on every pull request, which was the wrong design. See "Scoping" below.**

`Validate` runs only `npm run validate`, which never touches the Hugo site or the webpack bundle. Anything that breaks the website build passes CI and surfaces later in `Release Device Repository`, after the merge has already landed on master.

This is not theoretical: the four `/website` security bumps merged today — postcss, fast-uri, webpack-dev-server and shell-quote — had no CI coverage at all. They were built locally before merging, but nothing in the repo would have stopped a bad one. The failure mode is at least safe rather than destructive (if the build breaks, the deploy step never runs and `gh-pages` keeps serving the last good copy) but master is left in a state where every subsequent release fails.

### Scoping — why this is not a check on every PR

This repository is a source of **device data that vendors contribute to**, and the website is a downstream consumer of that data, not a gate on it. It is not a vendor's responsibility to keep the Hugo site building.

Around 40% of recent merged pull requests touch only `vendor/`, opened by device manufacturers. Showing them a red X caused by an internal Hugo or webpack problem would be confusing and unfair, and would make an internal website breakage look like a blocker on their device submission.

So this is a **separate workflow, scoped to the files the website build actually reads**:

- `website/**`
- `package.json` / `package-lock.json` — consumed by the `npm ci` step
- `schema.json` and `lib/**` — `website/tools/compile-schema.js` compiles these into standalone validators

A pull request touching only `vendor/` never triggers it. **`Validate` is left exactly as it was**, so nothing changes for vendor contributions.

Vendor data reaching the site stays covered where it is covered today: the generator consumes `vendor/` during `Release Device Repository` on every push to master.

### What runs

Nine build steps, **identical** to the build half of the `pages` job in `release.yml` — same Go (`~1.24`), Node (22), Hugo (0.159.2 extended), same `BASE_URL` / `BASE_PATH` — stopping immediately before the deploy, `devices.csv` and Airtable steps. A green check means the release build will succeed. Verified end-to-end: all nine steps pass.

### One caveat before making it required

A required status check that is **skipped by a paths filter never reports**, and GitHub then blocks the pull request while it waits for it. Making this check required as-is would block every vendor-only PR indefinitely — precisely the outcome the scoping above is meant to avoid.

If it should eventually be required, the usual pattern is a companion job with the inverse paths filter that reports success, so the context always reports one way or the other. Happy to add that in a follow-up; leaving it non-required for now is the safer default.
